### PR TITLE
AAP-43113: ansible.platform Documentation for token role incomplete/incorrect

### DIFF
--- a/plugins/modules/token.py
+++ b/plugins/modules/token.py
@@ -89,7 +89,7 @@ EXAMPLES = """
         aap_password: "{{ my_password }}"
 
     - name: Use our new token to make another call
-      namespace:
+      ansible.builtin.set_fact:
         aap_token: "{{ aap_token }}"
 
   always:


### PR DESCRIPTION
Description: The documentation for the ansible.platform.token module is inaccurate, causing an error when attempting to use the module. The example provided for using the token is incorrect, leading to the 'namespace' module not being recognized. To work around this issue, replace 'namespace' with 'ansible.builtin.set_fact'. 
Work Item link: https://issues.redhat.com/browse/AAP-43113
