### PR TITLE
[2.5 Backport] AAPRFE-1725 Accept AAP_* style inputs in ansible.platform collection

### DIFF
--- a/plugins/doc_fragments/auth.py
+++ b/plugins/doc_fragments/auth.py
@@ -12,43 +12,47 @@ class ModuleDocFragment(object):
     # Ansible Galaxy documentation fragment
     DOCUMENTATION = r"""
 options:
-  gateway_hostname:
+  aap_hostname:
     description:
     - URL to automation platform gateway.
-    - If value not set, will try environment variable C(GATEWAY_HOSTNAME)
+    - If value not set, will try environment variable C(GATEWAY_HOSTNAME), or E(AAP_HOSTNAME).
     - If value not specified by any means, the value of C(127.0.0.1) will be used
     type: str
-  gateway_username:
+    aliases: [ gateway_hostname ]
+  aap_username:
     description:
     - Username for your automation platform gateway.
-    - If value not set, will try environment variable C(GATEWAY_USERNAME)
+    - If value not set, will try environment variable C(GATEWAY_USERNAME), or E(AAP_USERNAME).
     type: str
-  gateway_password:
+    aliases: [ gateway_username ]
+  aap_password:
     description:
     - Password for your automation platform gateway.
-    - If value not set, will try environment variable C(GATEWAY_PASSWORD)
+    - If value not set, will try environment variable C(GATEWAY_PASSWORD), or E(AAP_PASSWORD).
     type: str
-  gateway_token:
+    aliases: [ gateway_password ]
+  aap_token:
     description:
     - The automation platform gateway token to use.
     - This value can be in one of two formats.
     - A string which is the token itself. (i.e. bqV5txm97wqJqtkxlMkhQz0pKhRMMX)
     - A dictionary structure as returned by the gateway_token module.
-    - If value not set, will try environment variable C(GATEWAY_API_TOKEN)
+    - If value not set, will try environment variable C(GATEWAY_API_TOKEN), or E(AAP_TOKEN).
     type: raw
-  gateway_validate_certs:
+    aliases: [ gateway_token ]
+  aap_validate_certs:
     description:
     - Whether to allow insecure connections to automation platform gateway.
     - If C(no), SSL certificates will not be validated.
     - This should only be used on personally controlled sites using self-signed certificates.
-    - If value not set, will try environment variable C(GATEWAY_VERIFY_SSL)
+    - If value not set, will try environment variable C(GATEWAY_VERIFY_SSL), or E(AAP_VALIDATE_CERTS).
     type: bool
-    aliases: [ validate_certs ]
-  gateway_request_timeout:
+    aliases: [ validate_certs, gateway_validate_certs ]
+  aap_request_timeout:
     description:
     - Specify the timeout Ansible should use in requests to the automation platform gateway.
     - Defaults to 10s, but this is handled by the shared module_utils code
-    - If value not set, will try environment variable C(GATEWAY_REQUEST_TIMEOUT)
+    - If value not set, will try environment variable C(GATEWAY_REQUEST_TIMEOUT), E(AAP_REQUEST_TIMEOUT)
     type: float
-    aliases: [ request_timeout ]
+    aliases: [ request_timeout, gateway_request_timeout ]
 """

--- a/plugins/module_utils/aap_module.py
+++ b/plugins/module_utils/aap_module.py
@@ -53,23 +53,30 @@ class AAPModule(AnsibleModule):
     AUTH_ARGSPEC = dict(
         gateway_hostname=dict(
             required=False,
-            fallback=(env_fallback, ["GATEWAY_HOSTNAME"]),
+            aliases=["aap_hostname"],
+            fallback=(env_fallback, ["GATEWAY_HOSTNAME", "AAP_HOSTNAME"]),
         ),
-        gateway_username=dict(required=False, fallback=(env_fallback, ["GATEWAY_USERNAME"])),
-        gateway_password=dict(no_log=True, required=False, fallback=(env_fallback, ["GATEWAY_PASSWORD"])),
+        gateway_username=dict(required=False, aliases=["aap_username"], fallback=(env_fallback, ["GATEWAY_USERNAME", "AAP_USERNAME"])),
+        gateway_password=dict(no_log=True, required=False, aliases=["aap_password"], fallback=(env_fallback, ["GATEWAY_PASSWORD", "AAP_PASSWORD"])),
         gateway_validate_certs=dict(
-            aliases=["validate_certs"],
+            aliases=["validate_certs", "aap_validate_certs"],
             type="bool",
             required=False,
-            fallback=(env_fallback, ["GATEWAY_VERIFY_SSL"]),
+            fallback=(env_fallback, ["GATEWAY_VERIFY_SSL", "AAP_VALIDATE_CERTS"]),
         ),
         gateway_token=dict(
             type="raw",
+            aliases=["aap_token"],
             no_log=True,
             required=False,
-            fallback=(env_fallback, ["GATEWAY_API_TOKEN"]),
+            fallback=(env_fallback, ["GATEWAY_API_TOKEN", 'AAP_TOKEN']),
         ),
-        gateway_request_timeout=dict(aliases=["request_timeout"], type="float", required=False, fallback=(env_fallback, ["GATEWAY_REQUEST_TIMEOUT"])),
+        gateway_request_timeout=dict(
+            aliases=["request_timeout", "aap_request_timeout"],
+            type="float",
+            required=False,
+            fallback=(env_fallback, ["GATEWAY_REQUEST_TIMEOUT", "AAP_REQUEST_TIMEOUT"]),
+        ),
     )
     ENCRYPTED_STRING = "$encrypted$"
     product_name = "automation platform gateway"


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->

- What is being changed?
Ensures that AAP_* variables can be used for authentication.

- Why is this change needed?

From https://issues.redhat.com/browse/AAPRFE-1725:
> Speaking anecdotally, we have consistently moved away from "Gateway" naming, just like the collection name, itself, was changed from "gateway" to "platform".

- How does this change address the issue?
Ensures that AAP_* variables can be used for authentication.


## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment