### PR TITLE
AAP-43078: addition of object_ids param to enable processing of a list of object_ids/names

### DIFF
--- a/plugins/modules/role_user_assignment.py
+++ b/plugins/modules/role_user_assignment.py
@@ -27,9 +27,19 @@ options:
         type: str
     object_id:
         description:
-            - Primary key of the object this assignment applies to.
+            - B(Deprecated)
+            - This option is deprecated and will be removed in a release after 2026-01-31.
+            - For associating a user to team(s)/organization(s), please use the object_ids param.
+            - HORIZONTALLINE
+            - Primary key/Name of the object this assignment applies to.
         required: False
         type: int
+    object_ids:
+        description:
+            - List of object IDs or names this assignment applies to.
+        required: False
+        type: list
+        elements: str
     user:
         description:
             - The name or id of the user to assign to the object.
@@ -63,17 +73,59 @@ EXAMPLES = '''
     object_id: 1
     user: bob
     state: present
+
+- name: Give Bob Team admin role for teams with id 1 and name "team2"
+  ansible.platform.role_user_assignment:
+    role_definition: Team Admin
+    object_ids: ['1', 'team2']
+    user: bob
+    state: present
 ...
 '''
 
 from ..module_utils.aap_module import AAPModule
 
 
+def assign_user_role(module, auto_exit=False, **role_args):
+    """
+    Assigns a user role to a specific object.
+    Args:
+        module:(AAPModule) Ansible module instance.
+        auto_exit:(bool) If True, the module will exit automatically after the operation.
+        role_args:(dict) role assignment parameters.
+    """
+    if role_args.get('state') == 'exists' and not role_args.get('role_user_assignment'):
+
+        module.fail_json(
+            msg=(
+                f"User role assignment does not exist: {role_args.get('role_definition_str')}, "
+                f"user: {role_args.get('user_param') or role_args.get('user_ansible_id')}, "
+                f"object: {role_args.get('object_id') or role_args.get('object_ansible_id')}"
+            )
+        )
+
+        module.exit_json(**module.json_output)
+
+    elif role_args.get('state') == 'absent':
+        module.delete_if_needed(role_args.get('role_user_assignment'))
+
+    elif role_args.get('state') == 'present':
+        module.create_if_needed(
+            role_args.get('role_user_assignment'),
+            role_args.get('kwargs'),
+            endpoint='role_user_assignments',
+            item_type='role_user_assignment',
+            auto_exit=auto_exit
+        )
+    return
+
+
 def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
         user=dict(required=False, type='str'),
-        object_id=dict(required=False, type='int'),
+        object_id=dict(required=False, type="int"),
+        object_ids=dict(required=False, type='list', elements='str'),
         role_definition=dict(required=True, type='str'),
         object_ansible_id=dict(required=False, type='str'),
         user_ansible_id=dict(required=False, type='str'),
@@ -84,12 +136,15 @@ def main():
         argument_spec=argument_spec,
         mutually_exclusive=[
             ('user', 'user_ansible_id'),
-            ('object_id', 'object_ansible_id'),
+            ('object_ids', 'object_ansible_id'),
+            ('object_ids', 'object_id'),
+            ('object_id', 'object_ansible_id')
         ],
     )
 
     user_param = module.params.get('user')
     object_id = module.params.get('object_id')
+    object_ids = module.params.get('object_ids')
     role_definition_str = module.params.get('role_definition')
     object_ansible_id = module.params.get('object_ansible_id')
     user_ansible_id = module.params.get('user_ansible_id')
@@ -102,35 +157,72 @@ def main():
         'role_definition': role_definition['id'],
     }
 
-    if object_id is not None:
-        kwargs['object_id'] = object_id
+    if object_id:
+        object_id = [object_id]
+        kwargs['object_id'] = [object_id]
+        module.deprecate(
+            msg="The usage of 'object_id' parameter in the 'role_user_assignment' module is not recommended. "
+            "For associating a user to team(s)/organization(s), please use the 'object_ids' parameter. ",
+            date="2026-01-31",
+            collection_name="ansible.platform",
+        )
+    if object_ids is not None:
+        kwargs['object_id'] = object_ids
     if user is not None:
         kwargs['user'] = user['id']
-    if object_ansible_id is not None:
-        kwargs['object_ansible_id'] = object_ansible_id
     if user_ansible_id is not None:
         kwargs['user_ansible_id'] = user_ansible_id
 
-    role_user_assignment = module.get_one('role_user_assignments', **{'data': kwargs})
+    role_map = {
+        'Team': 'teams',
+        'Organization': 'organizations',
+    }
 
-    if state == 'exists':
-        if role_user_assignment is None:
-            module.fail_json(
-                msg=f'User role assignment does not exist: {role_definition_str}, '
-                f'user: {user_param or user_ansible_id}, object: {object_id or object_ansible_id}'
-            )
-        module.exit_json(**module.json_output)
+    entity_type = next((
+        mapped
+        for prefix, mapped in role_map.items()
+        if role_definition_str.startswith(prefix)
+    ), None)
+    object_param = object_ids or object_id
 
-    elif state == 'absent':
-        module.delete_if_needed(role_user_assignment)
+    role_args = {
+        'role_definition_str': role_definition_str,
+        'user_param': user_param,
+        'user_ansible_id': user_ansible_id,
+        'state': state,
+        'kwargs': kwargs,
+    }
 
-    elif state == 'present':
-        module.create_if_needed(
-            role_user_assignment,
-            kwargs,
-            endpoint='role_user_assignments',
-            item_type='role_user_assignment',
-        )
+    if role_definition_str.lower().startswith('platform') and role_definition["id"] == 1:
+        role_user_assignment = module.get_one('role_user_assignments', **{'data': kwargs})
+        role_args['role_user_assignment'] = role_user_assignment
+        assign_user_role(module, **role_args)
+
+    elif entity_type and object_param:
+
+        for entity in object_param:
+
+            if not isinstance(entity, int):
+                response = module.get_one(entity_type, allow_none=True, name_or_id=entity)
+                if response is None:
+                    module.fail_json(
+                        msg=f"Unable to find {entity_type} with name or id: {entity}"
+                    )
+                entity = response.get('id')
+
+            if entity:
+                kwargs['object_id'] = entity
+
+            role_user_assignment = module.get_one('role_user_assignments', **{'data': kwargs})
+            role_args['role_user_assignment'] = role_user_assignment
+
+            assign_user_role(module, **role_args)
+
+    elif object_ansible_id:
+        kwargs["object_ansible_id"] = object_ansible_id
+        assign_user_role(module, **role_args)
+
+    module.exit_json(**module.json_output)
 
 
 if __name__ == '__main__':

--- a/tests/integration/targets/role_user_assignments_test/tasks/main.yml
+++ b/tests/integration/targets/role_user_assignments_test/tasks/main.yml
@@ -8,6 +8,7 @@
   ansible.builtin.set_fact:
     username: "GW-Collection-Test-RoleUserAssignments-{{ test_id }}"
     organization_name: "GW-Collection-Test-Organization-{{ test_id }}"
+    name_prefix: "GW-Collection-Test-Team-{{ test_id }}"
 
 - name: Run Tests
   module_defaults:
@@ -28,10 +29,30 @@
       ansible.builtin.assert:
         that:
           - user is changed
-    # </Users> -------------------
+
+    - name: Create User2
+      ansible.platform.user:
+        username: "{{ username }}--User-2"
+      register: user2
+
+    - name: Assert a creation changes the system
+      ansible.builtin.assert:
+        that:
+          - user2 is changed
+
+    - name: Create User3
+      ansible.platform.user:
+        username: "{{ username }}--User-3"
+      register: user3
+
+    - name: Assert a creation changes the system
+      ansible.builtin.assert:
+        that:
+          - user3 is changed
+
 
     # <Organizations> -------------------
-    - name: Create Organizations
+    - name: Create Organization 1
       ansible.platform.organization:
         name: "{{ organization_name }}"
       register: org
@@ -40,20 +61,155 @@
       ansible.builtin.assert:
         that:
           - org is changed
+
+    - name: Create Organization 2
+      ansible.platform.organization:
+        name: "{{ organization_name }}-2"
+      register: org2
+
+    - name: Assert a creation changes the system
+      ansible.builtin.assert:
+        that:
+          - org2 is changed
     # </Organizations> -------------------
+
+    # <Teams> -------------------
+    - name: Create Team 1
+      ansible.platform.team:
+        name: "{{ name_prefix }}-Team-1"
+        organization: "{{ org.name }}" # Org by name
+        description: Team 1
+      register: team1
+
+    - name: Assert that the creation changed the system
+      ansible.builtin.assert:
+        that:
+          - team1 is changed
+
+    - name: Create Team 2
+      ansible.platform.team:
+        name: "{{ name_prefix }}-Team-2"
+        organization: "{{ org2.name }}" # Org by name
+        description: Team 2
+      register: team2
+
+    - name: Assert that the creation changed the system
+      ansible.builtin.assert:
+        that:
+          - team2 is changed
+    # </Teams> -------------------
 
     # # <Role User Assignments> -------------------
     - name: Assign Admins by Role User Assignments
-      ansible.platform.role_user_assignment:
+      ansible.platform.role_user_assignment: &org_assignment
         object_id: "{{ org.id }}"
         role_definition: Organization Admin
-        user: "{{ user.id }}"
+        user: "{{ user2.id }}"
       register: org_admin_role_assignment
 
     - name: Assert that adding user as org admin worked
       ansible.builtin.assert:
         that:
           - org_admin_role_assignment is changed
+
+    # Multiple assignments
+    - name: Assign Admins by Role User Assignments (idempotent check)
+      ansible.platform.role_user_assignment: *org_assignment
+      register: org_admin_role_assignment_check
+
+    - name: Assert that org_admin_role_assignment_check is not changed
+      ansible.builtin.assert:
+        that:
+          - org_admin_role_assignment_check is not changed
+
+    - name: Assign Organization Admin by Role User Assignments
+      ansible.platform.role_user_assignment: &orgs_assignment
+        object_ids: ["{{ org.id }}", "{{ organization_name }}-2"]
+        role_definition: Organization Admin
+        user: "{{ user3.id }}"
+      register: org_admin_role_assignment2
+
+    - name: Assert that adding user as org admin worked
+      ansible.builtin.assert:
+        that:
+          - org_admin_role_assignment2 is changed
+
+    - name: Assign Organization Admin by Role User Assignments (idempotent check)
+      ansible.platform.role_user_assignment: *orgs_assignment
+      register: org_admin_role_assignment2_check
+
+    - name: Assert that org_admin_role_assignment2_check is not changed
+      ansible.builtin.assert:
+        that:
+          - org_admin_role_assignment2_check is not changed
+
+    - name: Assign Team Admin by Role User Assignments
+      ansible.platform.role_user_assignment: &team_assignment
+        object_ids: ["{{ team1.id }}", "{{ name_prefix }}-Team-2"]
+        role_definition: Team Admin
+        user: "{{ user2.id }}"
+      register: team_admin_role_assignment
+
+    - name: Assert that adding user as team admin worked
+      ansible.builtin.assert:
+        that:
+          - team_admin_role_assignment is changed
+
+    - name: Assign Team Admin by Role User Assignments (idempotent check)
+      ansible.platform.role_user_assignment: *team_assignment
+      register: team_admin_role_assignment_check
+
+    - name: Assert that team_admin_role_assignment_check is not changed
+      ansible.builtin.assert:
+        that:
+          - team_admin_role_assignment_check is not changed
+
+    - name: Assign Platform Auditor by Role User Assignments
+      ansible.platform.role_user_assignment: &platform_auditor_assignment
+        role_definition: Platform Auditor
+        user: "{{ user3.id }}"
+      register: platform_auditor_role_assignment
+
+    - name: Assert that adding user as team admin worked
+      ansible.builtin.assert:
+        that:
+          - platform_auditor_role_assignment is changed
+
+    - name: Assign Platform Auditor by Role User Assignments check
+      ansible.platform.role_user_assignment: *platform_auditor_assignment
+      register: platform_auditor_role_assignment_check
+
+    - name: Assert that platform_auditor_role_assignment_check is not changed
+      ansible.builtin.assert:
+        that:
+          - platform_auditor_role_assignment_check is not changed
+
+    - name: Delete Role User Assignments for Organization Admin
+      ansible.platform.role_user_assignment:
+        state: absent
+        object_ids: ["{{ org.id }}", "{{ organization_name }}-2"]
+        role_definition: Organization Admin
+        user: "{{ user3.id }}"
+      register: delete_role_user_assignment
+
+    - name: Check Existence of Role User Assignments for orgs
+      ansible.platform.role_user_assignment:
+        state: exists
+        object_ids: ["{{ org.id }}", "{{ organization_name }}-2"]
+        role_definition: Organization Admin
+        user: "{{ user3.id }}"
+      register: role_definition_exists_check
+      ignore_errors: true
+
+    - name: Assert that the role role_definition_exists_check is failed
+      ansible.builtin.assert:
+        that:
+          - role_definition_exists_check is failed
+
+    - name: Assert that removing user as org admin worked
+      ansible.builtin.assert:
+        that:
+          - delete_role_user_assignment is changed
 
     - name: Check Existence of Role User Assignments
       ansible.platform.role_user_assignment:


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
The datatype of _object_id_ param is being changed to list type in the role_user_assignment module
- Why is this change needed?
This change will enable the end_users to pass multiple objects for user role assignment. This would also support the object names in addition to object ids
for example: if we want to assign "user1" as a Team Admin to multiple team the object id list can look something like: ["1","team1","team2"]
- How does this change address the issue?
 Object_id to accept a list of object ids/names and assign the required role 

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1.  Create a Playbook for assign User with roles supported by AAP 
2. Pass the object_id as a list of object IDs/Name 
3. Run the playbook and validate the role assignment in the result as well as AAP 

Example: 

```
- name: Give user1 Team admin role for org 1
      ansible.platform.role_user_assignment:
        role_definition: Team Admin
        object_ids: ['{{  team1.id }}' , 'Team2']
        user: "User1"
        state: present
```



### Expected Results
<!-- Describe what should happen after following the steps -->
Validate if the playbook task was run successfully 

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
