### PR TITLE
[2.5 Backport] AAP-44752 AAPModule class should correctly handle idempotent scenarios with create_if_needed() when auto_exit=False

### DIFF
--- a/changelogs/fragments/create_if_needed.yaml
+++ b/changelogs/fragments/create_if_needed.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - "Ensure idempotent cases are correctly handled in AAPModule create_if_needed() method when auto_exit is disabled."

--- a/plugins/module_utils/aap_module.py
+++ b/plugins/module_utils/aap_module.py
@@ -466,6 +466,7 @@ class AAPModule(AnsibleModule):
             # If we don't have an existing_item, we can try to create it
             # We have to rely on item_type being passed in since we don't have an existing item that declares its type
             # We will pull the item_name out from the new_item, if it exists
+            response = {}
             item_name = self.get_item_name(new_item, allow_unknown=True)
             response = self.make_request("POST", item_url, **{"data": new_item})
 
@@ -497,9 +498,10 @@ class AAPModule(AnsibleModule):
             on_create(self, response["json"])
         elif auto_exit:
             self.exit_json(**self.json_output)
-        else:
+        elif not existing_item:
             last_data = response["json"]
             return last_data
+        return None
 
     def update_if_needed(
         self,


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/AAP-44752
Closes: https://issues.redhat.com/browse/AAP-45247