### PR TITLE
[2.5 Backport] AAP-44107 Improve object_ansible_id related documentation/examples in role_user_assignment module; AAP-45286 [ansible.platform] role_user_assignment fails when using object_ansible_id in the task

### DIFF
--- a/plugins/modules/role_user_assignment.py
+++ b/plugins/modules/role_user_assignment.py
@@ -32,27 +32,32 @@ options:
             - For associating a user to team(s)/organization(s), please use the object_ids param.
             - HORIZONTALLINE
             - Primary key/Name of the object this assignment applies to.
+            - This option is mutually exclusive with I(object_ids) and I(object_ansible_id).
         required: False
         type: int
     object_ids:
         description:
-            - List of object IDs or names this assignment applies to.
+            - List of object IDs(Primary Key ) or names this assignment applies to.
+            - This option is mutually exclusive with I(object_id) and I(object_ansible_id).
         required: False
         type: list
         elements: str
     user:
         description:
             - The name or id of the user to assign to the object.
+            - This option is mutually exclusive with I(user_ansible_id).
         required: False
         type: str
     object_ansible_id:
         description:
-            - Resource id of the object this role applies to. Alternative to the object_id field.
+            - UUID of the object(team/organization) this role applies to. Alternative to the object_id/object_ids field.
+            - This option is mutually exclusive with I(object_id) and I(object_ids)
         required: False
         type: str
     user_ansible_id:
         description:
             - Resource id of the user who will receive permissions from this assignment. Alternative to user field.
+            - This option is mutually exclusive with I(user).
         required: False
         type: str
     state:
@@ -80,6 +85,14 @@ EXAMPLES = '''
     object_ids: ['1', 'team2']
     user: bob
     state: present
+
+- name: Give Bob team admin role for org 1 using object_ansible_id
+  ansible.platform.role_user_assignment:
+    role_definition: Team Admin
+    object_ansible_id: c891b9f7-cc08-4b62-9843-c9ebfda262a9
+    user: bob
+    state: present
+
 ...
 '''
 
@@ -220,6 +233,8 @@ def main():
 
     elif object_ansible_id:
         kwargs["object_ansible_id"] = object_ansible_id
+        role_user_assignment = module.get_one('role_user_assignments', **{'data': kwargs})
+        role_args['role_user_assignment'] = role_user_assignment
         assign_user_role(module, **role_args)
 
     module.exit_json(**module.json_output)

--- a/tests/integration/targets/role_user_assignments_test/tasks/main.yml
+++ b/tests/integration/targets/role_user_assignments_test/tasks/main.yml
@@ -50,6 +50,15 @@
         that:
           - user3 is changed
 
+    - name: Create User4
+      ansible.platform.user:
+        username: "{{ username }}--User-4"
+      register: user4
+
+    - name: Assert a creation changes the system
+      ansible.builtin.assert:
+        that:
+          - user4 is changed
 
     # <Organizations> -------------------
     - name: Create Organization 1
@@ -99,6 +108,13 @@
           - team2 is changed
     # </Teams> -------------------
 
+    - name: Fetch Ansible ID for team2 & organization 2
+      ansible.builtin.set_fact:
+        team2_ansible_id: "{{ query('ansible.platform.gateway_api', 'teams/' + (team2.id | string),
+         **connection_info)[0].summary_fields.resource.ansible_id }}"
+        org2_ansible_id: "{{ query('ansible.platform.gateway_api', 'organizations/' + (org2.id | string),
+         **connection_info)[0].summary_fields.resource.ansible_id }}"
+
     # # <Role User Assignments> -------------------
     - name: Assign Admins by Role User Assignments
       ansible.platform.role_user_assignment: &org_assignment
@@ -143,6 +159,27 @@
         that:
           - org_admin_role_assignment2_check is not changed
 
+    - name: Assign Organization Admin by Role User Assignments with object_ansible_id
+      ansible.platform.role_user_assignment: &orgs_assignment3
+        object_ansible_id: "{{ org2_ansible_id }}"
+        role_definition: Organization Admin
+        user: "{{ user.id }}"
+      register: org_admin_role_assignment3
+
+    - name: Assert that adding user as org admin worked for org2
+      ansible.builtin.assert:
+        that:
+          - org_admin_role_assignment3 is changed
+
+    - name: Assign Organization Admin by Role User Assignments (idempotent check)
+      ansible.platform.role_user_assignment: *orgs_assignment3
+      register: org_admin_role_assignment3_check
+
+    - name: Assert that org_admin_role_assignment3_check is not changed
+      ansible.builtin.assert:
+        that:
+          - org_admin_role_assignment3_check is not changed
+
     - name: Assign Team Admin by Role User Assignments
       ansible.platform.role_user_assignment: &team_assignment
         object_ids: ["{{ team1.id }}", "{{ name_prefix }}-Team-2"]
@@ -164,6 +201,28 @@
         that:
           - team_admin_role_assignment_check is not changed
 
+    - name: Assign Team Admin by Role User Assignments for team2 with user4
+      ansible.platform.role_user_assignment: &team2_admin_assignment
+        object_ansible_id: "{{ team2_ansible_id }}"
+        role_definition: Team Admin
+        user: "{{ user4.id }}"
+        state: present
+      register: team2_admin_role_assignment
+
+    - name: Assert that adding user as team2 admin worked
+      ansible.builtin.assert:
+        that:
+          - team2_admin_role_assignment is changed
+
+    - name: Assign Team Admin by Role User Assignments for team2 with user4 (idempotent check)
+      ansible.platform.role_user_assignment: *team2_admin_assignment
+      register: team2_admin_role_assignment_check
+
+    - name: Assert that team2_admin_role_assignment_check is not changed
+      ansible.builtin.assert:
+        that:
+          - team2_admin_role_assignment_check is not changed
+
     - name: Assign Platform Auditor by Role User Assignments
       ansible.platform.role_user_assignment: &platform_auditor_assignment
         role_definition: Platform Auditor
@@ -183,6 +242,60 @@
       ansible.builtin.assert:
         that:
           - platform_auditor_role_assignment_check is not changed
+
+    - name: Delete Role User Assignments for Team Admin with object_ansible_id
+      ansible.platform.role_user_assignment:
+        state: absent
+        object_ansible_id: "{{ team2_ansible_id }}"
+        user: "{{ user4.id }}"
+        role_definition: Team Admin
+      register: delete_role_user_assignment_team3
+
+    - name: Assert that removing user as team admin worked
+      ansible.builtin.assert:
+        that:
+          - delete_role_user_assignment_team3 is changed
+
+    - name: Check Existence of Role User Assignments for team2
+      ansible.platform.role_user_assignment:
+        state: exists
+        object_ansible_id: "{{ team2_ansible_id }}"
+        role_definition: Team Admin
+        user: "{{ user4.id }}"
+      register: role_definition_exists_check_team3
+      ignore_errors: true
+
+    - name: Assert that the role role_definition_exists_check_team3 is failed
+      ansible.builtin.assert:
+        that:
+          - role_definition_exists_check_team3 is failed
+
+    - name: Delete Role User Assignments for Organization Admin with object_ansible_id
+      ansible.platform.role_user_assignment:
+        state: absent
+        object_ansible_id: "{{ org2_ansible_id }}"
+        role_definition: Organization Admin
+        user: "{{ user.id }}"
+      register: delete_role_user_assignment_org
+
+    - name: Assert that removing user as org admin worked
+      ansible.builtin.assert:
+        that:
+          - delete_role_user_assignment_org is changed
+
+    - name: Check Existence of Role User Assignments for org2
+      ansible.platform.role_user_assignment:
+        state: exists
+        object_ansible_id: "{{ org2_ansible_id }}"
+        role_definition: Organization Admin
+        user: "{{ user.id }}"
+      register: role_definition_exists_check_org2
+      ignore_errors: true
+
+    - name: Assert that the role role_definition_exists_check_org2 is failed
+      ansible.builtin.assert:
+        that:
+          - role_definition_exists_check_org2 is failed
 
     - name: Delete Role User Assignments for Organization Admin
       ansible.platform.role_user_assignment:
@@ -235,12 +348,16 @@
   # # <Cleanup>
   always:
   # Always Cleanup
-    - name: Delete user
+    - name: Delete users
       ansible.platform.user:
-        username: "{{ username }}"
+        username: "{{ item }}"
         state: absent
-      register: delete
-      ignore_errors: true
+      when: "item in vars and 'id' in vars[item]"
+      loop:
+        - "{{ username }}--User-1"
+        - "{{ username }}--User-2"
+        - "{{ username }}--User-3"
+        - "{{ username }}--User-4"
 
     - name: Delete Organizations
       ansible.platform.organization:
@@ -249,4 +366,15 @@
       when: "item in vars and 'id' in vars[item]"
       loop:
         - "org"
+        - "{{ organization_name }}"
+        - "{{ organization_name }}-2"
+
+    - name: Delete all Teams
+      ansible.platform.team:
+        name: "{{ item }}"
+        state: absent
+      when: "item in vars and 'id' in vars[item]"
+      loop:
+        - "{{ name_prefix }}-Team-1"
+        - "{{ name_prefix }}-Team-2"
 ...


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/AAP-45286 & https://issues.redhat.com/browse/AAP-44107
Closes: https://issues.redhat.com/browse/AAP-48042 & https://issues.redhat.com/browse/AAP-48041