### PR TITLE
[AAP-48722] Deprecate authenticator_uid and authenticators fields

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
+env:
+  PY_COLORS: '1'
+  ANSIBLE_FORCE_COLOR: '1'
 jobs:
   integration:
     name: collection integration test

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ collection-test: collection-install
 	echo 'gateway_password: $(GATEWAY_PASSWORD)' > /tmp/collections/ansible_collections/ansible/platform/tests/integration/integration_config.yml && \
 	cat /tmp/collections/ansible_collections/ansible/platform/tests/integration/integration_config.yml && \
 	cd /tmp/collections/ansible_collections/ansible/platform && \
-	  ansible-test integration --venv --requirements --coverage
+	  ansible-test integration --color yes --venv --requirements --coverage
 
 ## Run the collections test-integration check to see if all modules have integration tests
 collection-test-integration-check:

--- a/plugins/modules/user.py
+++ b/plugins/modules/user.py
@@ -73,11 +73,19 @@ options:
       default: true
     authenticators:
       description:
+        - B(Deprecated)
+        - This option is deprecated and will be removed in a release after 2026-01-31.
+        - For associating a user with authenticators, please use the associated_authenticators option.
+        - HORIZONTALLINE
         - A list of authenticators to associate the user with
       type: list
       elements: str
     authenticator_uid:
       description:
+        - B(Deprecated)
+        - This option is deprecated and will be removed in a release after 2026-01-31.
+        - For specifying UIDs per authenticator, please use the associated_authenticators option.
+        - HORIZONTALLINE
         - The UID to associate with this users authenticators
       type: str
     associated_authenticators:
@@ -176,6 +184,22 @@ def main():
         module.deprecate(
             msg="Configuring auditor via `ansible.platform.user` is not the recommended approach. "
             "The preferred method going forward is to use the `ansible.platform.role_user_assignment` module.",
+            date="2026-01-31",
+            collection_name="ansible.platform",
+        )
+
+    if module.params["authenticator_uid"]:
+        module.deprecate(
+            msg="The 'authenticator_uid' parameter is deprecated and will be removed in a future version. "
+            "Please use 'associated_authenticators' instead to specify UIDs per authenticator.",
+            date="2026-01-31",
+            collection_name="ansible.platform",
+        )
+
+    if module.params["authenticators"]:
+        module.deprecate(
+            msg="The 'authenticators' parameter is deprecated and will be removed in a future version. "
+            "Please use 'associated_authenticators' instead to specify authenticator associations.",
             date="2026-01-31",
             collection_name="ansible.platform",
         )

--- a/tests/integration/targets/users_test/tasks/main.yml
+++ b/tests/integration/targets/users_test/tasks/main.yml
@@ -280,6 +280,54 @@
         that:
           - invalid_org_result is failed
 
+    # Test deprecation warnings for both fields
+    - name: Test deprecation warning for both authenticators and authenticator_uid fields
+      ansible.platform.user:
+        username: "{{ username }}-deprecation-test"
+        first_name: DeprecationTest
+        password: "{{ 65535 | random | to_uuid }}"
+        authenticators: [1]
+        authenticator_uid: "test_uid"
+      register: deprecation_both_result
+
+    - name: Assert that deprecation warnings were shown for both fields
+      ansible.builtin.assert:
+        that:
+          - deprecation_both_result.deprecations is defined
+          - deprecation_both_result.deprecations | length > 0
+          - "'deprecated' in deprecation_both_result.deprecations[0].msg"
+
+
+    # Test deprecation warnings for authenticator_uid field
+    - name: Test deprecation warning for authenticator_uid field
+      ansible.platform.user:
+        username: "{{ username }}-deprecation-test1"
+        first_name: DeprecationTest1
+        password: "{{ 65535 | random | to_uuid }}"
+        authenticator_uid: "test_uid"
+      register: deprecation_uid_result
+
+    - name: Assert that deprecation warning was shown for authenticator_uid
+      ansible.builtin.assert:
+        that:
+          - deprecation_uid_result.deprecations is defined
+          - deprecation_uid_result.deprecations | length > 0
+          - "'authenticator_uid' in deprecation_uid_result.deprecations[0].msg"
+          - "'deprecated' in deprecation_uid_result.deprecations[0].msg"
+
+    # Test no deprecation warning when deprecated fields are not used
+    - name: Test no deprecation warning when deprecated fields are not used
+      ansible.platform.user:
+        username: "{{ username }}-no-deprecation"
+        first_name: NoDeprecation
+        password: "{{ 65535 | random | to_uuid }}"
+      register: no_deprecation_result
+
+    - name: Assert that no deprecation warning was shown
+      ansible.builtin.assert:
+        that:
+          - no_deprecation_result.deprecations is not defined or no_deprecation_result.deprecations | length == 0
+
   always:
     # Always Cleanup
     - name: Delete organizations
@@ -302,6 +350,10 @@
         - "timmy-{{ username }}"
         - "{{ username }}-noorg"
         - "{{ username }}-multiorg"
+        - "{{ username }}-deprecation-test"
+        - "{{ username }}-deprecation-test2"
+        - "{{ username }}-deprecation-test3"
+        - "{{ username }}-no-deprecation"
       register: delete_results
       ignore_errors: true
 


### PR DESCRIPTION
Issue: AAP-48722

## Description
This PR deprecates the `authenticator_uid` and `authenticators` fields in the `ansible.platform.user` module. This change is being made to streamline the user-authenticator association process and pave the way for future enhancements. The `associated_authenticators` field should be used instead.

- What is being changed?
  - The `authenticator_uid` and `authenticators` fields in the `ansible.platform.user` module are now deprecated.
  - The module will now issue a deprecation warning when these fields are used.
  - Integration tests have been added to verify the deprecation warnings.
  - The CI/CD pipeline has been updated to provide colored output for better readability.

- Why is this change needed?
  - To improve the user experience by providing a more intuitive and flexible way to associate users with authenticators.
  - To prepare for the eventual removal of the deprecated fields.

- How does this change address the issue?
  - By clearly marking the fields as deprecated and providing a clear path forward for users.
  - By adding tests to ensure the deprecation mechanism is working as expected.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [x] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
### Prerequisites
- An Ansible environment with the `ansible.platform` collection installed.
- An instance of AAP (Ansible Automation Platform) to test against.

### Steps to Test
1. Create a playbook that uses the `ansible.platform.user` module with the deprecated `authenticator_uid` and `authenticators` fields.
2. Run the playbook.
3. Verify that a deprecation warning is displayed in the playbook output.
4. Create a playbook that uses the `ansible.platform.user` module with the `associated_authenticators` field.
5. Run the playbook.
6. Verify that no deprecation warning is displayed.
7. Run the integration tests to ensure they pass: `make collection-test`

### Expected Results
- Playbooks using the deprecated fields should run successfully but display a deprecation warning.
- Playbooks using the new `associated_authenticators` field should run successfully without any warnings.
- All integration tests should pass.

## Additional Context
This change is part of a larger effort to improve the management of users and authenticators in the Ansible Automation Platform.

### Required Actions
- [x] Requires documentation updates
- [ ] Requires downstream repository changes
- [ ] Requires infrastructure/deployment changes
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX
