### PR TITLE
AAP-47990 - Bugfix: add a fix to let the pagination to work well

### DIFF
--- a/changelogs/fragments/fix_pagination.yaml
+++ b/changelogs/fragments/fix_pagination.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Strip scheme and hostname from AAP url builder, which previously lead to malformed urls in the ansible.platform.gateway_api lookup plugin
+...

--- a/plugins/module_utils/aap_module.py
+++ b/plugins/module_utils/aap_module.py
@@ -232,6 +232,9 @@ class AAPModule(AnsibleModule):
             super(AAPModule, self).warn(warning)
 
     def build_url(self, endpoint, query_params=None):
+        # Remove the host_url part if it is already present
+        if endpoint.startswith(("https://", "http://")):
+            endpoint = "/{0}".format('/'.join(endpoint.split('/')[3:]))
         # Make sure we start with /api/vX
         if not endpoint.startswith("/"):
             endpoint = "/{0}".format(endpoint)


### PR DESCRIPTION
## Description

<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed? **The `build_url` function at `plugins/module_utils/aap_module.py` file**
- Why is this change needed? **Because of `ansible.platform.gateway_api` lookup plugin pagination errors**
- How does this change address the issue? **Ensures the url never is starting with `^https{0,1}://[^/]+` before prepending that again**

```yaml
release: "2.5", "2.6", "2.7", "2.8", "devel"
backport: (optional) "2.5", "2.6", "2.7", "2.8"
needs_feature_branch: false
```


## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [X] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [X] I have considered the security impact of these changes
- [X] I have considered performance implications
- [X] I have thought about error handling and edge cases
- [X] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->
Have an AAP with, for example, an automation hub instance with more than 10 roles (tests can be tweaked below changing the `limit`).
### Steps to Test
1. Run a playbook to get all the hub roles:
    `$ cat /tmp/test.yaml`
    ```yaml
    ---
    - name: test playbook
      hosts: localhost
      connection: local
      gather_facts: false
      vars:
        controller_configuration_inventories_enforce_defaults: false
        controller_configuration_inventory_sources_enforce_defaults: false
        aap_validate_certs: false
        aap_hostname: localhost:8080
        aap_username: admin
        aap_password: redhat00
        query_hub_api_max_objects: 1000000
      tasks:
        - name: "Get current Roles from the Hub API"
          ansible.builtin.set_fact:
            hub_roles_lookvar: "{{ query('ansible.platform.gateway_api', '/api/galaxy/pulp/api/v3/roles/',
                                         query_params=({'name': role_name, 'limit': 10} if role_name is defined else {'limit': 10}),
                                         host=aap_hostname, username=aap_username, password=aap_password, verify_ssl=aap_validate_certs,
                                         return_all=true, max_objects=query_hub_api_max_objects)
                                }}"
        - name: "Show the query results"
          ansible.builtin.debug:
            var: hub_roles_lookvar
    ...
    ```
    `$ ansible-playbook -i localhost, /tmp/test.yaml`
2. The execution without the patch will look as follows:
    ```
    PLAY [test playbook] *************************************************************************************************************************************************************************************************************************
    
    TASK [Get current Roles from the Hub API] ****************************************************************************************************************************************************************************************************
    fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'ansible.platform.gateway_api'. Error was a <class 'ansible.errors.AnsibleError'>, original message: The requested object could not be found at api/gateway/v1/https://localhost:8080/api/galaxy/pulp/api/v3/roles/?limit=10&offset=10, response: HTTP Error 404: Not Found. The requested object could not be found at api/gateway/v1/https://localhost:8080/api/galaxy/pulp/api/v3/roles/?limit=10&offset=10, response: HTTP Error 404: Not Found"}
    
    PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
    localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
    ```

### Expected Results
<!-- Describe what should happen after following the steps -->
The execution result should not fail and contain all the roles available throuhg the API:

`$ ansible-playbook -i localhost, /tmp/test.yaml`
```
PLAY [test playbook] *************************************************************************************************************************************************************************************************************************

TASK [Get current Roles from the Hub API] ****************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Show the query results] ****************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "hub_roles_lookvar": [
        {
            "description": null,
            "locked": true,
            "name": "galaxy.auditor",
            "permissions": [
                "ansible.view_ansiblerepository",
                "ansible.view_collectionremote",
                "core.view_task",
                "galaxy.view_group",
                "galaxy.view_user"
            ],
            "pulp_created": "2025-07-28T07:04:27.842667Z",
            "pulp_href": "/api/galaxy/pulp/api/v3/roles/01984fd8-d7c2-77ed-bb01-b5eaadf00dfc/",
            "pulp_last_updated": "2025-07-28T07:04:27.844024Z"
        },
...
        {
            "description": null,
            "locked": true,
            "name": "core.contentredirectcontentguard_creator",
            "permissions": [
                "core.add_contentredirectcontentguard"
            ],
            "pulp_created": "2025-07-23T07:35:02.695771Z",
            "pulp_href": "/api/galaxy/pulp/api/v3/roles/01983635-0b27-7a16-ae4f-1299f1fc21d9/",
            "pulp_last_updated": "2025-07-28T07:04:27.220708Z"
        }
    ]
}

TASK [Count the query results] ***************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "Returned items: 101"
}

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```
## Additional Context
<!-- Optional but helpful information -->
Original PR at https://github.com/ansible-automation-platform/aap-gateway/pull/965
### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
