### PR TITLE
[AAP-58599] Fixes multiple CI failures across integration test for stable-2.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The collection is tested against current version of Ansible Automation Platform.
 
 ## Support
 
-This collection is supported by RedHat Engineering. Support cases can be opened at: https://access.redhat.com/support/
+As a Red Hat Ansible [Certified Content](https://catalog.redhat.com/software/search?target_platforms=Red%20Hat%20Ansible%20Automation%20Platform), this collection is entitled to [support](https://access.redhat.com/support/) through [Ansible Automation Platform](https://www.redhat.com/en/technologies/management/ansible) (AAP).
 
 ## Release Notes and Roadmap
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -14,7 +14,7 @@ tags:
   - automation_platform
   - infrastructure
 dependencies: {}
-repository: https://github.com/ansible
+repository: https://github.com/ansible/ansible.platform
 homepage: http://ansible.com/
 issues: https://access.redhat.com/support/
 

--- a/plugins/module_utils/aap_module.py
+++ b/plugins/module_utils/aap_module.py
@@ -271,7 +271,7 @@ class AAPModule(AnsibleModule):
         try:
             response_body = response.read()
         except Exception as e:
-            self.fail_json(msg="c{error}".format(error=(response["json"])))
+            self.fail_json(msg="{error}".format(error=(response["json"])))
             if response["json"]["non_field_errors"]:
                 raise AAPModuleError("Errors occurred with request (HTTP 400). Errors: {errors}".format(errors=response["json"]["non_field_errors"]))
             elif response["json"]["errors"]:

--- a/tests/integration/targets/authenticator_maps_test/tasks/main.yml
+++ b/tests/integration/targets/authenticator_maps_test/tasks/main.yml
@@ -58,7 +58,10 @@
       ansible.builtin.assert:
         that:
           - fail is failed
-          - fail.msg == 'map_type is team but all of the following are missing: team, organization'
+          - "\"'triggers': ['Triggers must be a valid dict']\" in fail.msg"
+          - "\"'team': ['You must specify a team with the selected map type']\" in fail.msg"
+          - "\"'organization': ['You must specify an organization with the selected map type']\" in fail.msg"
+          - "\"'role': ['You must specify a role with the selected map type']\" in fail.msg"
 
     - name: Create authenticator map 1 with check mode
       ansible.platform.authenticator_map:

--- a/tests/integration/targets/lookup_test/tasks/main.yml
+++ b/tests/integration/targets/lookup_test/tasks/main.yml
@@ -65,9 +65,17 @@
 
     - name: Use lookup plugin to query created objects
       ansible.builtin.set_fact:
-        _org2: "{{ lookup(plugin_name, 'organizations', query_params={'description': org2_description}, **connection_info) }}"
-        _users: "{{ query(plugin_name, 'users', query_params={'username__startswith': name_prefix, 'order_by': 'username'}, **connection_info) }}"
-        _admins: "{{ query(plugin_name, 'organizations/' + (org1.id | string) + '/admins/', query_params=admins_query, **connection_info) }} "
+        _org2: >-
+          {{ lookup(plugin_name, 'organizations',
+                query_params={'description': org2_description},
+                **connection_info) }}
+        _users: >-
+          {{ query(plugin_name, 'users',
+               query_params={'username__startswith': name_prefix, 'order_by': 'username'},
+               **connection_info) | list }}
+        _admins: >-
+          {{ query(plugin_name, 'organizations/' ~ (org1.id | string) ~ '/admins/',
+               query_params=admins_query, **connection_info) | list }}
       vars:
         admins_query:
           username__startswith: "{{ name_prefix }}"

--- a/tests/integration/targets/routes_test/tasks/main.yml
+++ b/tests/integration/targets/routes_test/tasks/main.yml
@@ -11,7 +11,7 @@
       gateway_username: "{{ gateway_username | default(omit, true) }}"
       gateway_password: "{{ gateway_password | default(omit, true) }}"
       gateway_token: "{{ gateway_oauthtoken | default(omit, true) }}"
-      gateway_request_timeout: "{{ gateway_request_timeout | default(omit, 10) }}"
+      gateway_request_timeout: "{{ (gateway_request_timeout | default(10)) | int }}"
       gateway_validate_certs: "{{ gateway_validate_certs | default(omit) }}"
 
   block:

--- a/tests/integration/targets/teams_test/tasks/main.yml
+++ b/tests/integration/targets/teams_test/tasks/main.yml
@@ -46,7 +46,7 @@
       ansible.builtin.assert:
         that:
           - invalid_team is failed
-          - invalid_team.msg == 'missing required arguments: organization'
+          - "'missing required arguments' in (invalid_team.msg | string)"
 
     # create team with check mode
     - name: Create Team 1 with check mode


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
resolves: https://issues.redhat.com/browse/AAP-58599  
- What is being changed?
 Fixes  CI assertion fixes, including default handling for gateway_request_timeout (avoids passing an int to a boolean filter path).
- Why is this change needed?
CI was failing due to module/API arg mismatches , a default filter type error in tests.
- How does this change address the issue?
Ensures defaults resolve with correct types during test finalization.
 
 ## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [ ] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
