### PR TITLE
[AAP-55913] Backport pagination fix PR #84 to stable-2.6

### DIFF
--- a/changelogs/fragments/fix_pagination.yaml
+++ b/changelogs/fragments/fix_pagination.yaml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - Strip scheme and hostname from AAP url builder, which previously lead to malformed urls in the ansible.platform.gateway_api lookup plugin
+  - Strip scheme and hostname from AAP url builder, which previously led to malformed URLs in the ansible.platform.gateway_api lookup plugin
 ...

--- a/changelogs/fragments/fix_pagination.yaml
+++ b/changelogs/fragments/fix_pagination.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Strip scheme and hostname from AAP url builder, which previously lead to malformed urls in the ansible.platform.gateway_api lookup plugin
+...

--- a/plugins/module_utils/aap_module.py
+++ b/plugins/module_utils/aap_module.py
@@ -232,6 +232,9 @@ class AAPModule(AnsibleModule):
             super(AAPModule, self).warn(warning)
 
     def build_url(self, endpoint, query_params=None):
+        # Remove the host_url part if it is already present
+        if endpoint.startswith(("https://", "http://")):
+            endpoint = "/{0}".format('/'.join(endpoint.split('/')[3:]))
         # Make sure we start with /api/vX
         if not endpoint.startswith("/"):
             endpoint = "/{0}".format(endpoint)

--- a/plugins/module_utils/aap_module.py
+++ b/plugins/module_utils/aap_module.py
@@ -234,7 +234,11 @@ class AAPModule(AnsibleModule):
     def build_url(self, endpoint, query_params=None):
         # Remove the host_url part if it is already present
         if endpoint.startswith(("https://", "http://")):
-            endpoint = "/{0}".format('/'.join(endpoint.split('/')[3:]))
+        if endpoint.startswith(("https://", "http://")):
+            parsed = urlparse(endpoint)
+            endpoint = parsed.path
+            if parsed.query:
+                endpoint = "{0}?{1}".format(endpoint, parsed.query)
         # Make sure we start with /api/vX
         if not endpoint.startswith("/"):
             endpoint = "/{0}".format(endpoint)

--- a/plugins/module_utils/aap_module.py
+++ b/plugins/module_utils/aap_module.py
@@ -234,7 +234,6 @@ class AAPModule(AnsibleModule):
     def build_url(self, endpoint, query_params=None):
         # Remove the host_url part if it is already present
         if endpoint.startswith(("https://", "http://")):
-        if endpoint.startswith(("https://", "http://")):
             parsed = urlparse(endpoint)
             endpoint = parsed.path
             if parsed.query:


### PR DESCRIPTION
## Description

**Fixes**
- https://issues.redhat.com/browse/AAP-55913

**What is being changed?**
- Backporting the `build_url` fix from PR #84 to `stable-2.6`
- The function now strips scheme and hostname from fully-qualified URLs before processing

**Why is this change needed?**
- Customers on AAP 2.6 are experiencing 404 errors when `ansible.platform.gateway_api` lookup plugin fetches paginated results
- The `build_url` function incorrectly prepends `api/gateway/v1/` to fully-qualified URLs returned in pagination responses

**How does this change address the issue?**
- Strips the scheme and hostname from URLs starting with `http://` or `https://` before further processing
- Prevents malformed paths like `api/gateway/v1/https://hostname/api/...`

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites
- AAP 2.6 environment with Private Automation Hub

### Steps to Test
1. Run the following playbook:
```yaml
---
- name: test playbook
  hosts: localhost
  connection: local
  gather_facts: false
  vars:
    aap_validate_certs: false
    aap_hostname: <your-aap-host>
    aap_username: admin
    aap_password: <password>
  tasks:
    - name: "Get roles from Hub API (limit=5 forces pagination)"
      ansible.builtin.set_fact:
        hub_roles: "{{ query('ansible.platform.gateway_api', '/api/galaxy/pulp/api/v3/roles/',
                             query_params={'limit': 5},
                             host=aap_hostname, username=aap_username, password=aap_password,
                             verify_ssl=aap_validate_certs, return_all=true, max_objects=10000) }}"
    - name: "Show roles count"
      ansible.builtin.debug:
        msg: "Retrieved {{ hub_roles | length }} roles"
```

### Expected Results
- All pages of results should be fetched without 404 errors
- No malformed URLs like `api/gateway/v1/https://...` in error messages

### Tested Results
- **Without fix**: Failed with `api/gateway/v1/https://<host>/api/galaxy/pulp/api/v3/roles/?limit=5&offset=5` (404)
- **With fix**: Successfully retrieved 124 roles across multiple pages

## Additional Context

Backport of:
- #84 (SHA: 60f4705e0c0349dd34701694def4d4594426365a)

Original PR merged to `devel` on Dec 11, 2025. This backport brings the fix to customers on the stable-2.6 release line.

### Required Actions
- [ ] Requires documentation updates
- [ ] Requires downstream repository changes
  - Consider backporting to `stable-2.5` as well
- [ ] Requires infrastructure/deployment changes
- [ ] Requires coordination with other teams
- [ ] Blocked by PR/MR: #XXX