### PR TITLE
fix issue when state: absent is used with existing_token

### DIFF
--- a/plugins/modules/token.py
+++ b/plugins/modules/token.py
@@ -181,6 +181,10 @@ def main():
                     }
                 },
             )
+        elif 'url' not in existing_token:
+            # When passed a registered variable instead of the aap_token fact,
+            # the token data is nested inside ansible_facts.aap_token
+            existing_token = existing_token.get('ansible_facts', {}).get('aap_token', existing_token)
 
         # If the state was absent we can let the module delete it if needed, the module will handle exiting from this
         module.delete_if_needed(existing_token)


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
token.py (ansible.platform.token module)
- Why is this change needed?
Address https://github.com/ansible/ansible.platform/issues/128
- How does this change address the issue?
When existing_token is provided but lacks a url key, extract the actual token data from the ansible_facts.aap_token path before passing it to delete_if_needed(). 

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [X] I have performed a self-review of my code
- [X] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [X] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. Have AAP 2.6 instance and required variables for config as code (host, password..etc).
2. Use simple playbook
```
---
- hosts: localhost
  gather_facts: false
  tasks:
    - name: Authenticate with AAP and obtain token
      ansible.platform.token:
      register: __aap_token

    - name: Revoke authentication token
      ansible.platform.token:
        existing_token: "{{ __aap_token }}"
        state: absent

```
3. Run playbook. 

### Expected Results
The playbook should exit without error, the token should be created and removed successfully.

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
