### PR TITLE
feat(AAP-68127): OIDC User Identity

### DIFF
--- a/plugins/modules/token.py
+++ b/plugins/modules/token.py
@@ -51,10 +51,14 @@ options:
       type: str
     scope:
       description:
-        - Allowed scopes, further restricts user's permissions. Must be a simple space-separated string with allowed scopes ['read', 'write'].
+        - Allowed scopes, further restricts user's permissions.
+        - "Acceptable values are: 'read', 'write', 'openid', 'roles'."
+        - Multiple scopes can be provided as a list to combine them (e.g. openid + roles for OIDC identity and role claims).
+        - A single scope can also be provided as a string for convenience.
       required: False
-      type: str
-      choices: ["read", "write"]
+      type: list
+      elements: str
+      choices: ["read", "write", "openid", "roles"]
     state:
       description:
         - Desired state of the resource.
@@ -99,6 +103,14 @@ EXAMPLES = """
         state: absent
       when: token is defined
 
+- name: Create a token with openid and roles scopes for OIDC
+  ansible.platform.token:
+    description: 'OIDC token'
+    scope:
+      - openid
+      - roles
+    state: present
+
 - name: Delete a token by its id
   ansible.platform.token:
     existing_token_id: 4
@@ -140,7 +152,7 @@ def main():
         description=dict(),
         application=dict(),
         organization=dict(),
-        scope=dict(choices=['read', 'write']),
+        scope=dict(type='list', elements='str', choices=['read', 'write', 'openid', 'roles']),
         existing_token=dict(type='dict', no_log=False),
         existing_token_id=dict(),
         state=dict(choices=['present', 'absent'], default='present'),
@@ -202,7 +214,7 @@ def main():
     if application_id is not None:
         new_fields['application'] = application_id
     if scope is not None:
-        new_fields['scope'] = scope
+        new_fields['scope'] = ' '.join(scope)
 
     # If the state was present and we can let the module build or update the existing item, this will return on its own
     module.create_or_update_if_needed(

--- a/tests/integration/targets/tokens_test/tasks/main.yml
+++ b/tests/integration/targets/tokens_test/tasks/main.yml
@@ -87,6 +87,44 @@
         that:
           - failed_token is failed
 
+    - name: Create a token with openid scope
+      ansible.platform.token:
+        description: "{{ name_prefix }}-openid-token"
+        scope: openid
+      register: openid_token
+
+    - name: Assert that the openid token was created
+      ansible.builtin.assert:
+        that:
+          - openid_token is changed
+          - "'token' in aap_token"
+
+    - name: Create a token with roles scope
+      ansible.platform.token:
+        description: "{{ name_prefix }}-roles-token"
+        scope: roles
+      register: roles_token
+
+    - name: Assert that the roles token was created
+      ansible.builtin.assert:
+        that:
+          - roles_token is changed
+          - "'token' in aap_token"
+
+    - name: Create a token with openid + roles scopes
+      ansible.platform.token:
+        description: "{{ name_prefix }}-oidc-combined-token"
+        scope:
+          - openid
+          - roles
+      register: combined_token
+
+    - name: Assert that the combined scope token was created
+      ansible.builtin.assert:
+        that:
+          - combined_token is changed
+          - "'token' in aap_token"
+
     - name: Build an application token with an org
       ansible.platform.token:
         application: "{{ name_prefix }}-app1"
@@ -107,6 +145,9 @@
       loop:
         - "user_token"
         - "user_token_two"
+        - "openid_token"
+        - "roles_token"
+        - "combined_token"
         - "app_token"
       when: item in vars
 


### PR DESCRIPTION
## Description

- **What is being changed?** The `ansible.platform.token` module's `scope` parameter is updated to accept `openid` and `roles` in addition to the existing `read` and `write` choices. Integration tests are added to verify token creation with the new scopes.
- **Why is this change needed?** The upstream DAB repository now supports `openid` and `roles` as valid OAuth2 token scopes for OIDC user identity ([AAP-68127](https://issues.redhat.com/browse/AAP-68127)). Without this change, users cannot create tokens with these scopes via the Ansible collection module — the `choices` validation rejects them before the request reaches the API.
- **How does this change address the issue?** By adding `openid` and `roles` to the `choices` list in both the module documentation and `argument_spec`, the module stays in sync with the API's accepted scope values, allowing users to create OIDC-scoped tokens via automation.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Test update

## Self-Review Checklist

- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions

### Prerequisites

### Steps to Test

1. Run the existing token integration tests with the new scopes:
   ```bash
   ansible-test integration tokens_test
   ```

2. Alternatively, manually verify:
   ```yaml
   - name: Create a token with openid scope
     ansible.platform.token:
       description: "OIDC test token"
       scope: openid
       aap_hostname: "{{ gateway_hostname }}"
       aap_username: "{{ gateway_username }}"
       aap_password: "{{ gateway_password }}"
   ```

### Expected Results

- Token creation with `scope: openid` succeeds
- Token creation with `scope: roles` succeeds
- Token creation with `scope: read` and `scope: write` continues to work as before
- Invalid scopes (e.g., `scope: foo`) are still rejected

## Additional Context

### Required Actions

- [x] Requires downstream repository changes
  - Depends on [django-ansible-base#963](https://github.com/ansible/django-ansible-base/pull/963) — adds `openid` and `roles` to accepted scopes in DAB


### Related Links

- Epic: [AAP-68127 - AAP as an OIDC Provider - User Identity](https://issues.redhat.com/browse/AAP-68127)
- DAB PR: [django-ansible-base#963](https://github.com/ansible/django-ansible-base/pull/963)
