### PR TITLE
[AAP-66486] Bump version/notes-collection 2.7.20260313

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,37 @@ ansible.platform Release Notes
 .. contents:: Topics
 
 
+v2.7.20260313
+=============
+Added OIDC User Identity support for Ansible Automation Platform Gateway, enabling OpenID Connect integration for user authentication and authorization.
+
+New modules:
+* feature_flag - Manage feature flags in Automation Platform Gateway
+* ca_certificates - Manage CA certificates for mTLS
+* role_team_assignment - Add role team assignment module (AAP-50089)
+* role_definition - Add role definition module (AAP-50274)
+
+Additional changes:
+* Add request_timeout_seconds and idle_timeout_seconds attributes to route modules (AAP-66486)
+* Add enable_mtls attribute to route module for mutual TLS support (AAP-48345)
+* Add associated_authenticators parameter to users module (AAP-48878)
+* Add Gateway UI plugin Route Collection Module (AAP-44404)
+* Add object_ids parameter support for processing lists of object_ids/names (AAP-43078)
+* Add Organization Association Logic to user Module (AAP-41665)
+* Add option to create Auditor users in user module (AAP-43080)
+* Enhance documentation for gateway_api.py lookup plugin (AAP-64338)
+* Fix for custom role team assignment (AAP-57909)
+* Fix multiple assignment object deletion (AAP-52248)
+* Fix to honor check_mode flag (AAP-40779)
+* Fix idempotent cases in create_if_needed() when auto_exit is disabled (AAP-44752)
+* Strip scheme and hostname from AAP url builder parameters to prevent malformed URLs (AAP-47990)
+* Standardize host validation across modules
+* Fix Envoy configuration for checking health of service cluster nodes (AAP-37005)
+* Update get_aap_gateway_and_dab.py with updated repo url for ansible-gateway (AAP-49513)
+
+Deprecations:
+* Deprecate authenticator_uid and authenticators fields in favor of associated_authenticators
+
 v2.5.0
 ======
 Initial Release

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # Ansible Platform Collection
 
-## Changelog for v2.5.20250326
+## Changelog for v2.7.20260313
 
-* Added support for setting URL for applications
+* Added OIDC User Identity support for Ansible Automation Platform Gateway
+* New modules: feature_flag, ca_certificates, role_team_assignment, role_definition
+* Add request_timeout_seconds and idle_timeout_seconds to route modules
+* Add enable_mtls attribute to route module for mutual TLS support
+* Add associated_authenticators parameter to users module
+* Add Gateway UI plugin Route Collection Module
+* Enhanced organization association logic and auditor user support
+* Multiple bug fixes for role assignment, object deletion, and URL handling
+* Deprecated authenticator_uid and authenticators fields
 
 ## Description
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: ansible
 name: platform
 description: A collection of roles to manage Ansible automation platform gateway
-version: 2.5.20250326
+version: 2.7.20260313
 readme: README.md
 authors:
   - automation platform gateway <aap-project@googlegroups.com>  # TBD


### PR DESCRIPTION
Bumps version to 2.7.20260313 and updates documentation

We need this version bump to accommodate AAP-66486, so that the installers can contain this version of the collection 