### PR TITLE
Add the ability for the next_url during pagination to be fully qualified (like pulp api returns for example)

### DIFF
--- a/plugins/lookup/gateway_api.py
+++ b/plugins/lookup/gateway_api.py
@@ -122,6 +122,7 @@ EXAMPLES = """
 
 from ansible.errors import AnsibleError  # noqa
 from ansible.module_utils._text import to_native  # noqa
+from ansible.module_utils.six.moves.urllib.parse import urlparse  # noqa
 from ansible.plugins.lookup import LookupBase  # noqa
 from ansible.utils.display import Display  # noqa
 
@@ -136,6 +137,14 @@ class LookupModule(LookupBase):
 
     def warn_callback(self, warning):
         self.display.warning(warning)
+
+    @staticmethod
+    def _fetch_paginated_page(module, next_page):
+        """GET the next page. Absolute http(s) URLs are used as-is; relative paths use get_endpoint."""
+        next_page = to_native(next_page)
+        if next_page.startswith(("https://", "http://")):
+            return module.make_request("GET", urlparse(next_page))
+        return module.get_endpoint(next_page)
 
     def run(self, terms, variables=None, **kwargs):
         if len(terms) != 1:
@@ -180,7 +189,7 @@ class LookupModule(LookupBase):
 
             next_page = return_data['next']
             while next_page is not None:
-                next_response = module.get_endpoint(next_page)
+                next_response = self._fetch_paginated_page(module, next_page)
                 return_data['results'] += next_response['json']['results']
                 next_page = next_response['json']['next']
             return_data['next'] = None

--- a/plugins/lookup/gateway_api.py
+++ b/plugins/lookup/gateway_api.py
@@ -121,7 +121,7 @@ EXAMPLES = """
 """
 
 from ansible.errors import AnsibleError  # noqa
-from ansible.module_utils._text import to_native  # noqa
+from ansible.module_utils.common.text.converters import to_native  # noqa
 from ansible.module_utils.six.moves.urllib.parse import urlparse  # noqa
 from ansible.plugins.lookup import LookupBase  # noqa
 from ansible.utils.display import Display  # noqa

--- a/plugins/module_utils/aap_module.py
+++ b/plugins/module_utils/aap_module.py
@@ -13,7 +13,7 @@ import time
 from json import dumps, loads
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.six import string_types
 from ansible.module_utils.six.moves.http_cookiejar import CookieJar
 

--- a/plugins/module_utils/aap_module.py
+++ b/plugins/module_utils/aap_module.py
@@ -13,6 +13,7 @@ import time
 from json import dumps, loads
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible.module_utils._text import to_native
 from ansible.module_utils.six import string_types
 from ansible.module_utils.six.moves.http_cookiejar import CookieJar
 
@@ -232,6 +233,9 @@ class AAPModule(AnsibleModule):
             super(AAPModule, self).warn(warning)
 
     def build_url(self, endpoint, query_params=None):
+        if endpoint is None:
+            endpoint = ""
+        endpoint = to_native(endpoint)
         # Remove the host_url part if it is already present
         if endpoint.startswith(("https://", "http://")):
             endpoint = "/{0}".format('/'.join(endpoint.split('/')[3:]))


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
  - This add's the ability to support the `next_url` value ALREADY being fully qualified.
- Why is this change needed?
  - The Pulp API's `next_url` value is fully qualified unlike Controller's.
- How does this change address the issue?
  - It add's a check to see if it's already fully qualified or not, and handles the result accordingly.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. Export `hub_collections` (or any Hub object) when the object count is over the MAX.

### Expected Results
<!-- Describe what should happen after following the steps -->
- It should dump everything requested instead of giving a 404 error because it pre-pended the provided API endpoint path to the FRONT of the `next_url` value.

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
