### PR TITLE
[AAP-73743] Service key idempotency fix 2.7

### DIFF
--- a/plugins/action/service_key.py
+++ b/plugins/action/service_key.py
@@ -19,8 +19,8 @@ class ActionModule(BaseResourceActionPlugin):
 
     def _should_update(self, resource_data, find_result):
         """Override to strictly ignore write-only fields during idempotency checks.
-        
-        This prevents the API's 'null' responses for hidden fields from falsely 
+
+        This prevents the API's 'null' responses for hidden fields from falsely
         triggering a changed: true state against the user's playbook values.
         """
         res_data = {k: v for k, v in resource_data.items() if k not in self._WRITE_ONLY_FIELDS}
@@ -30,7 +30,7 @@ class ActionModule(BaseResourceActionPlugin):
     def _pre_execute_hook(self, ansible_data, write_only_data, validated_params, operation):
         """Re-inject write-only fields so they reach the API payload.
 
-        ``secret`` is strictly non-editable after creation, so we only inject 
+        ``secret`` is strictly non-editable after creation, so we only inject
         it for "create" operations, never for "update" (PATCH) requests.
         """
         if operation == "create":

--- a/plugins/action/service_key.py
+++ b/plugins/action/service_key.py
@@ -14,29 +14,33 @@ class ActionModule(BaseResourceActionPlugin):
     MODEL_CLASS = AnsibleServiceKey
     # mark_previous_inactive: operation-time directive; API never returns it.
     # secret: write-only; API returns null/hash, not the original value.
-    # Including either in _should_update() causes false positives.
-    _WRITE_ONLY_FIELDS = frozenset({"mark_previous_inactive", "secret"})
+    # secret_length: write-only; API returns null on GET requests.
+    _WRITE_ONLY_FIELDS = frozenset({"mark_previous_inactive", "secret", "secret_length"})
+
+    def _should_update(self, resource_data, find_result):
+        """Override to strictly ignore write-only fields during idempotency checks.
+        
+        This prevents the API's 'null' responses for hidden fields from falsely 
+        triggering a changed: true state against the user's playbook values.
+        """
+        res_data = {k: v for k, v in resource_data.items() if k not in self._WRITE_ONLY_FIELDS}
+        fnd_data = {k: v for k, v in find_result.items() if k not in self._WRITE_ONLY_FIELDS}
+        return super(ActionModule, self)._should_update(res_data, fnd_data)
 
     def _pre_execute_hook(self, ansible_data, write_only_data, validated_params, operation):
         """Re-inject write-only fields so they reach the API payload.
 
-        ``mark_previous_inactive`` and ``secret`` are excluded from the
-        AnsibleServiceKey dataclass (via _WRITE_ONLY_FIELDS) to prevent
-        false-positive idempotency checks — the API never echoes these
-        fields back in GET responses, so _should_update() would always
-        see None vs. a user-supplied value and report changed.
-
-        For create/update operations however, both fields must still reach
-        the transform and ultimately the API request body.  This hook puts
-        them back into ansible_data (from the write_only_data stash) so
-        the transform can include them when they are non-None.
-
-        Note: mark_previous_inactive=False is a valid explicit value and
-        must not be filtered out here — only skip genuinely absent (None)
-        values.
+        ``secret`` is strictly non-editable after creation, so we only inject 
+        it for "create" operations, never for "update" (PATCH) requests.
         """
-        if operation in ("create", "update"):
-            for field in ("mark_previous_inactive", "secret"):
+        if operation == "create":
+            for field in ("mark_previous_inactive", "secret", "secret_length"):
+                val = write_only_data.get(field)
+                if val is not None:
+                    ansible_data[field] = val
+        elif operation == "update":
+            # Secret is non-editable, do not inject it for PATCH
+            for field in ("mark_previous_inactive", "secret_length"):
                 val = write_only_data.get(field)
                 if val is not None:
                     ansible_data[field] = val

--- a/plugins/action/service_key.py
+++ b/plugins/action/service_key.py
@@ -17,14 +17,14 @@ class ActionModule(BaseResourceActionPlugin):
     # secret_length: write-only; API returns null on GET requests.
     _WRITE_ONLY_FIELDS = frozenset({"mark_previous_inactive", "secret", "secret_length"})
 
-    def _should_update(self, resource_data, find_result):
+    def _should_update(self, desired_data, current_data):
         """Override to strictly ignore write-only fields during idempotency checks.
 
         This prevents the API's 'null' responses for hidden fields from falsely
         triggering a changed: true state against the user's playbook values.
         """
-        res_data = {k: v for k, v in resource_data.items() if k not in self._WRITE_ONLY_FIELDS}
-        fnd_data = {k: v for k, v in find_result.items() if k not in self._WRITE_ONLY_FIELDS}
+        res_data = {k: v for k, v in desired_data.items() if k not in self._WRITE_ONLY_FIELDS}
+        fnd_data = {k: v for k, v in current_data.items() if k not in self._WRITE_ONLY_FIELDS}
         return super(ActionModule, self)._should_update(res_data, fnd_data)
 
     def _pre_execute_hook(self, ansible_data, write_only_data, validated_params, operation):

--- a/plugins/plugin_utils/api/v1/service_key.py
+++ b/plugins/plugin_utils/api/v1/service_key.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class APIServiceKey_v1(BaseTransformMixin):
+class APIServiceKey_v1:
     """API v1 representation of a service key."""
 
     name: Optional[str] = None
@@ -79,7 +79,7 @@ class ServiceKeyTransformMixin_v1(BaseTransformMixin):
             "update": EndpointOperation(
                 path="/api/gateway/v1/service_keys/{id}/",
                 method="PATCH",
-                fields=["name", "is_active", "service_cluster", "algorithm", "secret", "secret_length", "mark_previous_inactive"],
+                fields=["name", "is_active", "service_cluster", "algorithm", "secret_length", "mark_previous_inactive"],
                 path_params=["id"],
                 required_for="update",
                 order=1,
@@ -100,12 +100,16 @@ class ServiceKeyTransformMixin_v1(BaseTransformMixin):
         from ...ansible_models.service_key import AnsibleServiceKey
 
         sc = api_data.get("service_cluster")
+        secret = api_data.get("secret")
+        if secret == "$encrypted$":
+            secret = None
+            
         return AnsibleServiceKey(
             name=api_data.get("name", ""),
             is_active=api_data.get("is_active"),
             service_cluster=str(sc) if sc is not None else None,
             algorithm=api_data.get("algorithm"),
-            secret=api_data.get("secret"),
+            secret=secret,
             secret_length=api_data.get("secret_length"),
             mark_previous_inactive=api_data.get("mark_previous_inactive"),
             id=api_data.get("id"),

--- a/plugins/plugin_utils/api/v1/service_key.py
+++ b/plugins/plugin_utils/api/v1/service_key.py
@@ -103,7 +103,7 @@ class ServiceKeyTransformMixin_v1(BaseTransformMixin):
         secret = api_data.get("secret")
         if secret == "$encrypted$":
             secret = None
-            
+
         return AnsibleServiceKey(
             name=api_data.get("name", ""),
             is_active=api_data.get("is_active"),

--- a/tests/integration/targets/service_keys_test/tasks/main.yml
+++ b/tests/integration/targets/service_keys_test/tasks/main.yml
@@ -157,6 +157,21 @@
         that:
           - service_key1 is changed
 
+    - name: Re-run Service Key 1 with the same raw secret (idempotency)
+      ansible.platform.service_key:
+        name: "{{ name_prefix }}-Key 1"
+        is_active: true
+        service_cluster: "{{ controller_sc.service_cluster.id }}"
+        algorithm: HS384
+        secret: "gateway-secret"
+        mark_previous_inactive: false
+      register: rerun_service_key1_with_secret
+
+    - name: Assert that re-run with secret does not change the system
+      ansible.builtin.assert:
+        that:
+          - rerun_service_key1_with_secret is not changed
+
     # We have to take out the secret because its encrypted
     - name: Recreate Service Key 1
       ansible.platform.service_key:


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
The module was updated to classify secret and secret_length as write-only fields, ignoring them during state comparisons and explicitly stripping them from update payloads.
- Why is this change needed?
The API obscures secret values (returning "$encrypted$" or null), which previously caused Ansible to falsely detect configuration drift when compared against the user's plaintext playbook inputs.
- How does this change address the issue?
By filtering out these obscured fields during the internal diff check, the module accurately recognizes when the configuration matches the playbook and successfully halts the update loop.

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
