### PR TITLE
CI: install requests + force PR collection on devel

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,6 +44,17 @@ jobs:
         run: tools/scripts/get_aap_gateway_and_dab.py
         working-directory: ansible-platform
 
+      - name: Install requests for ansible.platform manager subprocess
+        # ansible.platform 2.7.20260513+ spawns a manager subprocess that imports
+        # requests. The subprocess receives its sys.path from the parent ansible-playbook
+        # process (via sys_path_list), which is a restricted subset that does NOT include
+        # /usr/lib/python3/dist-packages (where apt installs packages).
+        # Setting PYTHONPATH ensures Python adds that directory to sys.path at startup,
+        # so it flows through sys_path_list into the subprocess.
+        run: |
+          sudo apt-get install -y python3-requests
+          echo "PYTHONPATH=/usr/lib/python3/dist-packages${PYTHONPATH:+:${PYTHONPATH}}" >> $GITHUB_ENV
+
       - name: Expose collection checkout to aap-gateway build
         run: ln -s "${{ github.workspace }}/ansible-platform" "${{ github.workspace }}/aap-gateway/ansible.platform"
 
@@ -109,9 +120,31 @@ jobs:
         run: tools/scripts/get_aap_gateway_and_dab.py
         working-directory: ansible-platform
 
+      - name: Install requests for ansible.platform manager subprocess
+        # ansible.platform 2.7.20260513+ spawns a manager subprocess that imports
+        # requests. The subprocess receives its sys.path from the parent ansible-playbook
+        # process (via sys_path_list), which is a restricted subset that does NOT include
+        # /usr/lib/python3/dist-packages (where apt installs packages).
+        # Setting PYTHONPATH ensures Python adds that directory to sys.path at startup,
+        # so it flows through sys_path_list into the subprocess.
+        run: |
+          sudo apt-get install -y python3-requests
+          echo "PYTHONPATH=/usr/lib/python3/dist-packages${PYTHONPATH:+:${PYTHONPATH}}" >> $GITHUB_ENV
+
       - name: Start the dev environment
         run: COMPOSE_UP_OPTS='-d' make docker-compose
         working-directory: aap-gateway
+
+      - name: Force PR collection over any Galaxy-installed version
+        # make docker-compose installs the published Galaxy version of
+        # ansible.platform into ~/.ansible/collections, which shadows our PR
+        # changes.  Replace it with the checked-out PR code so all subsequent
+        # ansible-playbook calls use the PR collection.
+        run: |
+          mkdir -p ~/.ansible/collections/ansible_collections/ansible
+          rm -rf ~/.ansible/collections/ansible_collections/ansible/platform
+          cp -r ${{ github.workspace }}/ansible-platform \
+                ~/.ansible/collections/ansible_collections/ansible/platform
 
       - name: Install make
         run: sudo apt install make
@@ -122,7 +155,7 @@ jobs:
           python-version: 3.11
 
       - name: Install requirements
-        run: pip3.11 install -r requirements/requirements_dev.txt ansible-core
+        run: pip3.11 install -r requirements/requirements_dev.txt ansible-core requests
         working-directory: ansible-platform
 
       - name: Perform completeness tests
@@ -150,9 +183,31 @@ jobs:
         run: tools/scripts/get_aap_gateway_and_dab.py
         working-directory: ansible-platform
 
+      - name: Install requests for ansible.platform manager subprocess
+        # ansible.platform 2.7.20260513+ spawns a manager subprocess that imports
+        # requests. The subprocess receives its sys.path from the parent ansible-playbook
+        # process (via sys_path_list), which is a restricted subset that does NOT include
+        # /usr/lib/python3/dist-packages (where apt installs packages).
+        # Setting PYTHONPATH ensures Python adds that directory to sys.path at startup,
+        # so it flows through sys_path_list into the subprocess.
+        run: |
+          sudo apt-get install -y python3-requests
+          echo "PYTHONPATH=/usr/lib/python3/dist-packages${PYTHONPATH:+:${PYTHONPATH}}" >> $GITHUB_ENV
+
       - name: Start the dev environment
         run: COMPOSE_UP_OPTS='-d' make docker-compose
         working-directory: aap-gateway
+
+      - name: Force PR collection over any Galaxy-installed version
+        # make docker-compose installs the published Galaxy version of
+        # ansible.platform into ~/.ansible/collections, which shadows our PR
+        # changes.  Replace it with the checked-out PR code so all subsequent
+        # ansible-playbook calls use the PR collection.
+        run: |
+          mkdir -p ~/.ansible/collections/ansible_collections/ansible
+          rm -rf ~/.ansible/collections/ansible_collections/ansible/platform
+          cp -r ${{ github.workspace }}/ansible-platform \
+                ~/.ansible/collections/ansible_collections/ansible/platform
 
       - name: Install make
         run: sudo apt install make


### PR DESCRIPTION
Backport CI workarounds from stable-2.7 (6a675d2, 585738b) so that pull_request_target jobs — which load this workflow from the default branch — install python3-requests, set PYTHONPATH, and install the PR collection into ~/.ansible/collections before invoking ansible.platform modules.

Required after #171 synced the persistent-manager architecture into devel without porting the corresponding CI changes.

Unblocks #176, #178.

## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
- Why is this change needed?
- How does this change address the issue?

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [ ] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
