### PR TITLE
[AAP-76233]: restores the async: / poll: 0 parallelism

### DIFF
--- a/plugins/action/base_action.py
+++ b/plugins/action/base_action.py
@@ -219,6 +219,13 @@ class BaseResourceActionPlugin(ActionBase):
 
     MODULE_NAME = None  # Subclass must override
 
+    # Action plugins in ansible.platform always target localhost (Gateway is
+    # an HTTP API, connection is always local).  Ansible's fork-based async
+    # mechanism writes job-status files on the managed node; because the
+    # managed node IS the controller here, async_status can poll those files
+    # correctly.  Setting this to True restores the async: / poll: 0 behaviour
+    # that infra.aap_configuration gateway roles depend on.
+    _supports_async = True
     # -----------------------------------------------------------------
     # Declarative class variables: set these in a subclass to get a
     # fully-working action plugin without overriding run().


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
-A single class-level attribute is added to BaseResourceActionPlugin in plugins/action/base_action.py:
python_supports_async = True
BaseResourceActionPlugin is the base class that every ansible.platform action plugin inherits from. Previously it inherited the default _supports_async = False from Ansible's ActionBase, which caused Ansible to reject any task using async: before the action plugin even had a chance to run.

- Why is this change needed?
infra.aap_configuration — the collection that ships the Configuration as Code (CasC) experience for AAP — uses async: 1000, poll: 0 across all 15 gateway roles (gateway_organizations, gateway_teams, gateway_users, gateway_authenticators, and 11 others). This pattern fires all items in a loop simultaneously and collects results later via collect_async_status, giving genuine parallelism when configuring large AAP environments.
In stable-2.6, ansible.platform modules were standard Ansible modules (Python scripts transferred to and run on the managed node). Ansible's async mechanism works natively with modules, so async:/poll: 0 worked without any special handling.
In stable-2.7, all ansible.platform modules were rewritten as action plugins — running on the controller rather than the managed node. ActionBase._supports_async defaults to False, and Ansible enforces this by raising an error immediately when a task with async: is dispatched to an action plugin with _supports_async = False. This means every single gateway role in infra.aap_configuration crashes on the very first task, before any API call is even made.
- How does this change address the issue?
Setting _supports_async = True tells Ansible that this action plugin is safe to run asynchronously. This is correct and safe for ansible.platform for a specific structural reason: every ansible.platform task always runs against localhost with connection: local (Gateway is an HTTP API — there is no remote managed node). Because of this:

Ansible's async fork happens on the controller itself
The job status file (~/.ansible_async/<jid>) is written on the controller
async_status — which runs on the "managed node" (localhost = controller) — can find and poll that file

This is exactly the same topology that makes stable-2.6 async work: a forked Python process running independently, making its own HTTP request to Gateway, writing its result, and exiting. The fix restores that behaviour without any changes to the action plugin logic or the infra.aap_configuration roles.

Assisted By: Claude Code Sonnet 4.6 

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [ ] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
