### PR TITLE
Update the repository URL

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -15,7 +15,7 @@ tags:
   - infrastructure
 dependencies: {}
 
-repository: https://github.com/ansible
+repository: https://github.com/ansible/ansible.platform
 homepage: http://ansible.com/
 issues: https://access.redhat.com/support/
 


### PR DESCRIPTION
So that the Automation Hub link points to this repository

## Description
The link in AH pointed to the organization instead of the repository.
https://console.redhat.com/ansible/automation-hub/collections/published/ansible/platform/details

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
- [X] I have updated documentation where needed

## Testing Instructions
N/A

