### PR TITLE
[stable-2.7] Backport #198: fix search_api pagination (relative next + galaxy/hub envelope)

### DIFF
--- a/plugins/plugin_utils/manager/platform_manager.py
+++ b/plugins/plugin_utils/manager/platform_manager.py
@@ -14,7 +14,7 @@ from dataclasses import asdict
 from multiprocessing.managers import BaseManager
 from socketserver import ThreadingMixIn
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urljoin
 
 if TYPE_CHECKING:
     import requests
@@ -1175,7 +1175,10 @@ class PlatformService(BaseAPIClient):
                 raise ValueError("Endpoint '%s' returned %d objects which exceeds max_objects=%d" % (endpoint, total, max_objects))
             next_url = data.get("next")
             while next_url:
-                next_resp = self._make_request("get", next_url, operation="search_api_paginate", resource=endpoint)
+                # AAP returns 'next' as a relative path (e.g. '/api/controller/v2/job_templates/?page=2').
+                # Resolve it against base_url so session.get() receives an absolute URL.
+                absolute_next_url = urljoin(self.base_url, next_url)
+                next_resp = self._make_request("get", absolute_next_url, operation="search_api_paginate", resource=endpoint)
                 next_data = next_resp.json()
                 data["results"].extend(next_data.get("results", []))
                 next_url = next_data.get("next")

--- a/plugins/plugin_utils/manager/platform_manager.py
+++ b/plugins/plugin_utils/manager/platform_manager.py
@@ -1185,7 +1185,7 @@ class PlatformService(BaseAPIClient):
                     max_objects,
                     items_key="data",
                     next_getter=lambda d: (d.get("links") or {}).get("next"),
-                    total=data.get("meta", {}).get("count"),
+                    total=(data.get("meta") or {}).get("count"),
                 )
                 data["links"]["next"] = None
 
@@ -1214,6 +1214,10 @@ class PlatformService(BaseAPIClient):
             next_resp = self._make_request("get", absolute_next_url, operation="search_api_paginate", resource=endpoint)
             next_data = next_resp.json()
             data[items_key].extend(next_data.get(items_key, []))
+            # Guard against a stale/wrong server count or a cyclic 'next' link: bound the
+            # accumulated results independently of the first-page count check above.
+            if len(data[items_key]) > max_objects:
+                raise ValueError("Endpoint '%s' returned more than max_objects=%d objects while paginating" % (endpoint, max_objects))
             next_url = next_getter(next_data)
 
     def shutdown(self) -> dict:

--- a/plugins/plugin_utils/manager/platform_manager.py
+++ b/plugins/plugin_utils/manager/platform_manager.py
@@ -1157,8 +1157,11 @@ class PlatformService(BaseAPIClient):
             max_objects: Safety cap; raises ValueError when return_all would exceed this
 
         Returns:
-            Raw API response dict.  List endpoints look like
-            {'count': N, 'results': [...], 'next': ..., 'previous': ...}.
+            Raw API response dict.  Components behind the gateway use two list shapes:
+            - DRF style (gateway/controller/eda): {'count': N, 'results': [...],
+              'next': <path>, 'previous': ...}
+            - Galaxy/hub style: {'meta': {'count': N}, 'links': {'next': <path>, ...},
+              'data': [...]}.
             Detail endpoints (settings/ui, etc.) are returned as-is.
 
         Raises:
@@ -1169,22 +1172,49 @@ class PlatformService(BaseAPIClient):
         response = self._make_request("get", url, operation="search_api", resource=endpoint, params=query_params or {})
         data = response.json()
 
-        if return_all and "results" in data:
-            total = data.get("count", len(data["results"]))
-            if total > max_objects:
-                raise ValueError("Endpoint '%s' returned %d objects which exceeds max_objects=%d" % (endpoint, total, max_objects))
-            next_url = data.get("next")
-            while next_url:
-                # AAP returns 'next' as a relative path (e.g. '/api/controller/v2/job_templates/?page=2').
-                # Resolve it against base_url so session.get() receives an absolute URL.
-                absolute_next_url = urljoin(self.base_url, next_url)
-                next_resp = self._make_request("get", absolute_next_url, operation="search_api_paginate", resource=endpoint)
-                next_data = next_resp.json()
-                data["results"].extend(next_data.get("results", []))
-                next_url = next_data.get("next")
-            data["next"] = None
+        if return_all:
+            if "results" in data:
+                # DRF pagination: {count, next, previous, results}; 'next' is the top-level key.
+                self._collect_pages(data, endpoint, max_objects, items_key="results", next_getter=lambda d: d.get("next"), total=data.get("count"))
+                data["next"] = None
+            elif "data" in data and isinstance(data.get("links"), dict):
+                # Galaxy/hub pagination: {meta: {count}, links: {next}, data: [...]}.
+                self._collect_pages(
+                    data,
+                    endpoint,
+                    max_objects,
+                    items_key="data",
+                    next_getter=lambda d: (d.get("links") or {}).get("next"),
+                    total=data.get("meta", {}).get("count"),
+                )
+                data["links"]["next"] = None
 
         return data
+
+    def _collect_pages(self, data: dict, endpoint: str, max_objects: int, items_key: str, next_getter, total: Optional[int] = None) -> None:
+        """Follow pagination 'next' links in-place, extending data[items_key] with every page.
+
+        Args:
+            data: First-page response; mutated to accumulate all items.
+            endpoint: Endpoint fragment, used for error context.
+            max_objects: Safety cap; raises ValueError when the total would exceed it.
+            items_key: Key holding the list of objects ('results' for DRF, 'data' for hub).
+            next_getter: Callable returning the relative 'next' link for a page (or None).
+            total: Server-reported total count, if known; falls back to the first page size.
+        """
+        if total is None:
+            total = len(data[items_key])
+        if total > max_objects:
+            raise ValueError("Endpoint '%s' returned %d objects which exceeds max_objects=%d" % (endpoint, total, max_objects))
+        next_url = next_getter(data)
+        while next_url:
+            # AAP components return 'next' as a relative path (e.g. '/api/controller/v2/job_templates/?page=2').
+            # Resolve it against base_url so session.get() receives an absolute URL.
+            absolute_next_url = urljoin(self.base_url, next_url)
+            next_resp = self._make_request("get", absolute_next_url, operation="search_api_paginate", resource=endpoint)
+            next_data = next_resp.json()
+            data[items_key].extend(next_data.get(items_key, []))
+            next_url = next_getter(next_data)
 
     def shutdown(self) -> dict:
         """

--- a/tests/unit/plugins/plugin_utils/manager/test_search_api_pagination.py
+++ b/tests/unit/plugins/plugin_utils/manager/test_search_api_pagination.py
@@ -72,5 +72,53 @@ class TestSearchApiPagination(unittest.TestCase):
                 self.svc.search_api("job_templates", return_all=True, max_objects=2)
 
 
+class TestSearchApiHubPagination(unittest.TestCase):
+    """Galaxy/hub uses a different envelope: {meta: {count}, links: {next}, data: [...]}."""
+
+    def setUp(self):
+        self.svc = _make_platform_service(base_url="https://gw.example.com")
+
+    def test_hub_links_next_is_followed_and_resolved(self):
+        """Hub paginates via links.next (relative) over a 'data' list, not results/next."""
+        page1 = {
+            "meta": {"count": 2},
+            "links": {"first": "/api/galaxy/v3/namespaces/?limit=1&offset=0", "next": "/api/galaxy/v3/namespaces/?limit=1&offset=1", "previous": None},
+            "data": [{"name": "ns1"}],
+        }
+        page2 = {
+            "meta": {"count": 2},
+            "links": {"first": "/api/galaxy/v3/namespaces/?limit=1&offset=0", "next": None, "previous": "/api/galaxy/v3/namespaces/?limit=1&offset=0"},
+            "data": [{"name": "ns2"}],
+        }
+
+        with patch.object(self.svc, "_make_request", side_effect=[_resp(page1), _resp(page2)]) as mock_req:
+            result = self.svc.search_api("galaxy/v3/namespaces", return_all=True, max_objects=100)
+
+        # Pagination follow-up resolves the relative links.next against base_url.
+        paginated_url = mock_req.call_args_list[1].args[1]
+        self.assertEqual(paginated_url, "https://gw.example.com/api/galaxy/v3/namespaces/?limit=1&offset=1")
+
+        # All pages collected into 'data'; trailing links.next cleared.
+        self.assertEqual(result["data"], [{"name": "ns1"}, {"name": "ns2"}])
+        self.assertIsNone(result["links"]["next"])
+
+    def test_hub_max_objects_exceeded_raises(self):
+        page1 = {
+            "meta": {"count": 5},
+            "links": {"next": "/api/galaxy/v3/namespaces/?limit=1&offset=1"},
+            "data": [{"name": "ns1"}],
+        }
+        with patch.object(self.svc, "_make_request", side_effect=[_resp(page1)]):
+            with self.assertRaises(ValueError):
+                self.svc.search_api("galaxy/v3/namespaces", return_all=True, max_objects=2)
+
+    def test_hub_single_page_no_next(self):
+        page1 = {"meta": {"count": 1}, "links": {"next": None}, "data": [{"name": "ns1"}]}
+        with patch.object(self.svc, "_make_request", side_effect=[_resp(page1)]) as mock_req:
+            result = self.svc.search_api("galaxy/v3/namespaces", return_all=True, max_objects=100)
+        self.assertEqual(mock_req.call_count, 1)
+        self.assertEqual(result["data"], [{"name": "ns1"}])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/plugins/plugin_utils/manager/test_search_api_pagination.py
+++ b/tests/unit/plugins/plugin_utils/manager/test_search_api_pagination.py
@@ -71,6 +71,32 @@ class TestSearchApiPagination(unittest.TestCase):
             with self.assertRaises(ValueError):
                 self.svc.search_api("job_templates", return_all=True, max_objects=2)
 
+    def test_missing_count_falls_back_to_collected_length(self):
+        """When the response omits 'count', pagination still works (falls back to page length)."""
+        page1 = {"results": [{"id": 1}], "next": "/api/controller/v2/job_templates/?page=2"}
+        page2 = {"results": [{"id": 2}], "next": None}
+        with patch.object(self.svc, "_make_request", side_effect=[_resp(page1), _resp(page2)]):
+            result = self.svc.search_api("job_templates", return_all=True, max_objects=100)
+        self.assertEqual(result["results"], [{"id": 1}, {"id": 2}])
+
+    def test_stale_count_still_bounded_by_max_objects_in_loop(self):
+        """A wrong/stale 'count' must not let pagination exceed max_objects unbounded."""
+        # count=1 passes the first-page check, but the pages keep returning a 'next'.
+        page1 = {"count": 1, "results": [{"id": 1}], "next": "/api/controller/v2/job_templates/?page=2"}
+        page2 = {"count": 1, "results": [{"id": 2}], "next": "/api/controller/v2/job_templates/?page=3"}
+        page3 = {"count": 1, "results": [{"id": 3}], "next": "/api/controller/v2/job_templates/?page=4"}
+        with patch.object(self.svc, "_make_request", side_effect=[_resp(page1), _resp(page2), _resp(page3)]):
+            with self.assertRaises(ValueError):
+                self.svc.search_api("job_templates", return_all=True, max_objects=2)
+
+    def test_non_list_payload_passes_through_untouched(self):
+        """Detail endpoints (no 'results'/'data') are returned as-is even with return_all=True."""
+        detail = {"setting": "value", "nested": {"a": 1}}
+        with patch.object(self.svc, "_make_request", side_effect=[_resp(detail)]) as mock_req:
+            result = self.svc.search_api("settings/ui", return_all=True, max_objects=100)
+        self.assertEqual(mock_req.call_count, 1)
+        self.assertEqual(result, detail)
+
 
 class TestSearchApiHubPagination(unittest.TestCase):
     """Galaxy/hub uses a different envelope: {meta: {count}, links: {next}, data: [...]}."""
@@ -117,6 +143,13 @@ class TestSearchApiHubPagination(unittest.TestCase):
         with patch.object(self.svc, "_make_request", side_effect=[_resp(page1)]) as mock_req:
             result = self.svc.search_api("galaxy/v3/namespaces", return_all=True, max_objects=100)
         self.assertEqual(mock_req.call_count, 1)
+        self.assertEqual(result["data"], [{"name": "ns1"}])
+
+    def test_hub_null_meta_does_not_crash(self):
+        """A response with an explicit 'meta': null must not raise AttributeError."""
+        page1 = {"meta": None, "links": {"next": None}, "data": [{"name": "ns1"}]}
+        with patch.object(self.svc, "_make_request", side_effect=[_resp(page1)]):
+            result = self.svc.search_api("galaxy/v3/namespaces", return_all=True, max_objects=100)
         self.assertEqual(result["data"], [{"name": "ns1"}])
 
 

--- a/tests/unit/plugins/plugin_utils/manager/test_search_api_pagination.py
+++ b/tests/unit/plugins/plugin_utils/manager/test_search_api_pagination.py
@@ -1,0 +1,76 @@
+# (c) 2026 Red Hat Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for PlatformService.search_api pagination handling."""
+
+from __future__ import absolute_import, division, print_function
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ansible_collections.ansible.platform.plugins.plugin_utils.manager.platform_manager import PlatformService
+from ansible_collections.ansible.platform.plugins.plugin_utils.platform.config import GatewayConfig
+
+
+def _make_platform_service(base_url="https://gw.example.com"):
+    """PlatformService with network and credentials mocked."""
+    mock_session = MagicMock()
+    mock_requests = MagicMock()
+    mock_requests.Session.return_value = mock_session
+    mock_store = MagicMock()
+    mock_store.get_auth_credentials.return_value = ("admin", "admin", None)
+    with patch("ansible_collections.ansible.platform.plugins.plugin_utils.manager.platform_manager.get_credential_manager") as mock_cred:
+        mock_cred.return_value.get_or_create_store.return_value = mock_store
+        with patch("ansible_collections.ansible.platform.plugins.plugin_utils.manager.platform_manager._get_requests") as mock_get_requests:
+            mock_get_requests.return_value = mock_requests
+            config = GatewayConfig(base_url=base_url, username="admin", password="admin", idle_timeout=30.0)
+            return PlatformService(config)
+
+
+def _resp(payload):
+    r = MagicMock()
+    r.json.return_value = payload
+    return r
+
+
+class TestSearchApiPagination(unittest.TestCase):
+    def setUp(self):
+        self.svc = _make_platform_service(base_url="https://gw.example.com")
+
+    def test_relative_next_url_is_resolved_to_absolute(self):
+        """AAP returns 'next' as a relative path; it must be made absolute before GET."""
+        page1 = {"count": 2, "results": [{"id": 1}], "next": "/api/controller/v2/job_templates/?page=2", "previous": None}
+        page2 = {"count": 2, "results": [{"id": 2}], "next": None, "previous": None}
+
+        with patch.object(self.svc, "_make_request", side_effect=[_resp(page1), _resp(page2)]) as mock_req:
+            result = self.svc.search_api("job_templates", return_all=True, max_objects=100)
+
+        # Second request (the pagination follow-up) must receive an absolute URL.
+        paginate_call = mock_req.call_args_list[1]
+        paginated_url = paginate_call.args[1]
+        self.assertEqual(paginated_url, "https://gw.example.com/api/controller/v2/job_templates/?page=2")
+
+        # All pages collected; trailing 'next' cleared.
+        self.assertEqual(result["results"], [{"id": 1}, {"id": 2}])
+        self.assertIsNone(result["next"])
+
+    def test_absolute_next_url_passed_through_unchanged(self):
+        """If 'next' is already absolute it must be used as-is."""
+        page1 = {"count": 2, "results": [{"id": 1}], "next": "https://gw.example.com/api/controller/v2/job_templates/?page=2", "previous": None}
+        page2 = {"count": 2, "results": [{"id": 2}], "next": None, "previous": None}
+
+        with patch.object(self.svc, "_make_request", side_effect=[_resp(page1), _resp(page2)]) as mock_req:
+            self.svc.search_api("job_templates", return_all=True, max_objects=100)
+
+        paginated_url = mock_req.call_args_list[1].args[1]
+        self.assertEqual(paginated_url, "https://gw.example.com/api/controller/v2/job_templates/?page=2")
+
+    def test_max_objects_exceeded_raises(self):
+        page1 = {"count": 5, "results": [{"id": 1}], "next": "/api/controller/v2/job_templates/?page=2"}
+        with patch.object(self.svc, "_make_request", side_effect=[_resp(page1)]):
+            with self.assertRaises(ValueError):
+                self.svc.search_api("job_templates", return_all=True, max_objects=2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Backport of #198 to `stable-2.7`

Backports the `search_api` pagination fixes from #198 (merged to `devel`) to the `stable-2.7` release branch. The bug ships in all released 2.7 versions (2.7.20260513, 2.7.20260515, 2.7.20260604).

Cherry-picked clean from `devel`; no `galaxy.yml`/version change included.

### What's fixed

1. **Relative `next` links were never resolved (regression).** AAP components return the pagination `next` as a relative path (e.g. `/api/controller/v2/job_templates/?page=2`), which was passed straight to `_make_request()` → `session.get()` and failed. Multi-page `return_all` was broken. Regressed in #156; the old `aap_module.py` had resolved `next` via `build_url()`. Fix: `urllib.parse.urljoin(self.base_url, next_url)`.

2. **Galaxy/hub pagination envelope unsupported.** Hub list responses use `{meta: {count}, links: {next}, data: [...]}` rather than DRF `{count, next, results}`, so `return_all` silently returned only the first page for `/api/galaxy/` endpoints. Added a shared `_collect_pages()` helper handling both envelopes.

3. **Hardening (review feedback).** In-loop `max_objects` guard (bounds against stale/wrong `count` or cyclic `next`); null-safe `meta` read.

### Verified

- Against a live 2.7 gateway: gateway/controller/EDA/hub all return **relative** `next` paths — `urljoin` is correct for all.
- 10 unit tests in `test_search_api_pagination.py`; full manager suite: 58 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)