### PR TITLE
[AAP-80136] Fix application module to return client_secret when app c…

### DIFF
--- a/changelogs/fragments/aap_80136_client_secret.yaml
+++ b/changelogs/fragments/aap_80136_client_secret.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - application - fix ``client_secret`` not returned in module result when creating a confidential OAuth application (https://issues.redhat.com/browse/AAP-80136).

--- a/extensions/molecule/application_mock/converge.yml
+++ b/extensions/molecule/application_mock/converge.yml
@@ -57,7 +57,7 @@
       vars:
         ansible_connection: local
 
-    - name: Assert create changed and client_secret returned (AAP-801336)
+    - name: Assert create changed and client_secret returned (AAP-80136)
       ansible.builtin.assert:
         that:
           - create_result is changed
@@ -83,7 +83,7 @@
       vars:
         ansible_connection: local
 
-    - name: Assert idempotent run did not change and client_secret absent (AAP-801336)
+    - name: Assert idempotent run did not change and client_secret absent (AAP-80136)
       ansible.builtin.assert:
         that:
           - idem_result is not changed
@@ -105,7 +105,7 @@
       vars:
         ansible_connection: local
 
-    - name: Assert update changed and client_secret absent on PATCH (AAP-801336)
+    - name: Assert update changed and client_secret absent on PATCH (AAP-80136)
       ansible.builtin.assert:
         that:
           - update_result is changed
@@ -132,7 +132,7 @@
         description: "Created by Molecule"
       register: create_result
 
-    - name: Assert create changed and client_secret returned (AAP-801336)
+    - name: Assert create changed and client_secret returned (AAP-80136)
       ansible.builtin.assert:
         that:
           - create_result is changed
@@ -148,7 +148,7 @@
         state: present
       register: idem_result
 
-    - name: Assert idempotent run did not change and client_secret absent (AAP-801336)
+    - name: Assert idempotent run did not change and client_secret absent (AAP-80136)
       ansible.builtin.assert:
         that:
           - idem_result is not changed
@@ -162,7 +162,7 @@
         description: "Updated by Molecule"
       register: update_result
 
-    - name: Assert update changed and client_secret absent on PATCH (AAP-801336)
+    - name: Assert update changed and client_secret absent on PATCH (AAP-80136)
       ansible.builtin.assert:
         that:
           - update_result is changed
@@ -187,7 +187,7 @@
         description: "Created by Molecule"
       register: create_result
 
-    - name: Assert create changed and client_secret returned (AAP-801336)
+    - name: Assert create changed and client_secret returned (AAP-80136)
       ansible.builtin.assert:
         that:
           - create_result is changed
@@ -203,7 +203,7 @@
         state: present
       register: idem_result
 
-    - name: Assert idempotent run did not change and client_secret absent (AAP-801336)
+    - name: Assert idempotent run did not change and client_secret absent (AAP-80136)
       ansible.builtin.assert:
         that:
           - idem_result is not changed
@@ -217,7 +217,7 @@
         description: "Updated by Molecule"
       register: update_result
 
-    - name: Assert update changed and client_secret absent on PATCH (AAP-801336)
+    - name: Assert update changed and client_secret absent on PATCH (AAP-80136)
       ansible.builtin.assert:
         that:
           - update_result is changed

--- a/extensions/molecule/application_mock/converge.yml
+++ b/extensions/molecule/application_mock/converge.yml
@@ -57,10 +57,15 @@
       vars:
         ansible_connection: local
 
-    - name: Assert create changed
+    - name: Assert create changed and client_secret returned (AAP-801336)
       ansible.builtin.assert:
-        that: create_result is changed
-        fail_msg: "Create should report changed. create_result={{ create_result }}"
+        that:
+          - create_result is changed
+          - create_result.client_secret is defined
+          - create_result.client_secret | length > 0
+          - create_result.client_id is defined
+          - create_result.client_id | length > 0
+        fail_msg: "Create should report changed and return client_secret. create_result={{ create_result }}"
       vars:
         ansible_connection: local
 
@@ -78,10 +83,12 @@
       vars:
         ansible_connection: local
 
-    - name: Assert idempotent run did not change
+    - name: Assert idempotent run did not change and client_secret absent (AAP-801336)
       ansible.builtin.assert:
-        that: idem_result is not changed
-        fail_msg: "Idempotent run should not report changed. idem_result={{ idem_result }}"
+        that:
+          - idem_result is not changed
+          - idem_result.client_secret is not defined or idem_result.client_secret == None
+        fail_msg: "Idempotent run should not change and must not expose stale client_secret. idem_result={{ idem_result }}"
       vars:
         ansible_connection: local
 
@@ -98,10 +105,12 @@
       vars:
         ansible_connection: local
 
-    - name: Assert update changed
+    - name: Assert update changed and client_secret absent on PATCH (AAP-801336)
       ansible.builtin.assert:
-        that: update_result is changed
-        fail_msg: "Update should report changed. update_result={{ update_result }}"
+        that:
+          - update_result is changed
+          - update_result.client_secret is not defined or update_result.client_secret == None
+        fail_msg: "Update should change but must not expose client_secret on PATCH. update_result={{ update_result }}"
       vars:
         ansible_connection: local
 
@@ -123,10 +132,13 @@
         description: "Created by Molecule"
       register: create_result
 
-    - name: Assert create changed
+    - name: Assert create changed and client_secret returned (AAP-801336)
       ansible.builtin.assert:
-        that: create_result is changed
-        fail_msg: "Create should report changed. create_result={{ create_result }}"
+        that:
+          - create_result is changed
+          - create_result.client_secret is defined
+          - create_result.client_secret | length > 0
+        fail_msg: "Create should return client_secret. create_result={{ create_result }}"
 
     - name: Run again (idempotency)
       ansible.platform.application:
@@ -136,10 +148,12 @@
         state: present
       register: idem_result
 
-    - name: Assert idempotent run did not change
+    - name: Assert idempotent run did not change and client_secret absent (AAP-801336)
       ansible.builtin.assert:
-        that: idem_result is not changed
-        fail_msg: "Idempotent run should not report changed. idem_result={{ idem_result }}"
+        that:
+          - idem_result is not changed
+          - idem_result.client_secret is not defined or idem_result.client_secret == None
+        fail_msg: "Idempotent run must not expose stale client_secret. idem_result={{ idem_result }}"
 
     - name: Update application
       ansible.platform.application:
@@ -148,10 +162,12 @@
         description: "Updated by Molecule"
       register: update_result
 
-    - name: Assert update changed
+    - name: Assert update changed and client_secret absent on PATCH (AAP-801336)
       ansible.builtin.assert:
-        that: update_result is changed
-        fail_msg: "Update should report changed. update_result={{ update_result }}"
+        that:
+          - update_result is changed
+          - update_result.client_secret is not defined or update_result.client_secret == None
+        fail_msg: "Update must not expose client_secret on PATCH. update_result={{ update_result }}"
 
 - name: Converge — application (mock, http persistent)
   hosts: localhost
@@ -171,10 +187,13 @@
         description: "Created by Molecule"
       register: create_result
 
-    - name: Assert create changed
+    - name: Assert create changed and client_secret returned (AAP-801336)
       ansible.builtin.assert:
-        that: create_result is changed
-        fail_msg: "Create should report changed. create_result={{ create_result }}"
+        that:
+          - create_result is changed
+          - create_result.client_secret is defined
+          - create_result.client_secret | length > 0
+        fail_msg: "Create should return client_secret. create_result={{ create_result }}"
 
     - name: Run again (idempotency)
       ansible.platform.application:
@@ -184,10 +203,12 @@
         state: present
       register: idem_result
 
-    - name: Assert idempotent run did not change
+    - name: Assert idempotent run did not change and client_secret absent (AAP-801336)
       ansible.builtin.assert:
-        that: idem_result is not changed
-        fail_msg: "Idempotent run should not report changed. idem_result={{ idem_result }}"
+        that:
+          - idem_result is not changed
+          - idem_result.client_secret is not defined or idem_result.client_secret == None
+        fail_msg: "Idempotent run must not expose stale client_secret. idem_result={{ idem_result }}"
 
     - name: Update application
       ansible.platform.application:
@@ -196,8 +217,10 @@
         description: "Updated by Molecule"
       register: update_result
 
-    - name: Assert update changed
+    - name: Assert update changed and client_secret absent on PATCH (AAP-801336)
       ansible.builtin.assert:
-        that: update_result is changed
-        fail_msg: "Update should report changed. update_result={{ update_result }}"
+        that:
+          - update_result is changed
+          - update_result.client_secret is not defined or update_result.client_secret == None
+        fail_msg: "Update must not expose client_secret on PATCH. update_result={{ update_result }}"
 ...

--- a/plugins/action/application.py
+++ b/plugins/action/application.py
@@ -14,7 +14,8 @@ class ActionModule(BaseResourceActionPlugin):
     MODEL_CLASS = AnsibleApplication
 
     # API-generated; returned flat only, not in the nested dict (not round-trip safe as input).
-    _EXTRA_RETURN_FIELDS = frozenset({"client_id"})
+    # client_secret is only present in the POST response — absent on GET/PATCH.
+    _EXTRA_RETURN_FIELDS = frozenset({"client_id", "client_secret"})
 
     # redirect_uris fields are stored as space-separated strings by the API; split to list on output.
     _SPACE_SEPARATED_LIST_FIELDS = frozenset({"redirect_uris", "post_logout_redirect_uris"})

--- a/plugins/plugin_utils/ansible_models/application.py
+++ b/plugins/plugin_utils/ansible_models/application.py
@@ -41,10 +41,8 @@ class AnsibleApplication:
     modified: Optional[str] = None
     url: Optional[str] = None
 
-    # API-generated OAuth credentials — returned by the API on create/update,
-    # never accepted as module input (not in argument_spec).
-    # Surfaced in the flat top-level result only (via _EXTRA_RETURN_FIELDS),
-    # NOT included in the nested 'application' round-trip dict.
-    # client_secret is intentionally omitted — it is only present in the API
-    # response once on initial create and should not be stored or re-emitted.
+    # API-generated OAuth credentials — never accepted as input, not in argspec.
+    # Surfaced flat via _EXTRA_RETURN_FIELDS only, NOT in the nested dict.
     client_id: Optional[str] = None
+    # Returned by the Gateway API on create (POST) only; absent on GET/PATCH.
+    client_secret: Optional[str] = None

--- a/plugins/plugin_utils/api/v1/application.py
+++ b/plugins/plugin_utils/api/v1/application.py
@@ -244,6 +244,7 @@ class ApplicationTransformMixin_v1(BaseTransformMixin):
             created=api_data.get("created"),
             modified=api_data.get("modified"),
             url=api_data.get("url"),
-            # API-generated OAuth credential — surfaced flat only, not in nested dict.
+            # API-generated; client_secret only present in POST response.
             client_id=api_data.get("client_id"),
+            client_secret=api_data.get("client_secret"),
         )

--- a/tests/integration/targets/applications_test/tasks/main.yml
+++ b/tests/integration/targets/applications_test/tasks/main.yml
@@ -200,7 +200,7 @@
           - app5.client_id | length > 0
         fail_msg: "confidential app create must return client_secret and client_id. app5={{ app5 }}"
 
-    - name: Re-run app5 idempotency — client_secret must be absent on re-run (AAP-801336)
+    - name: Re-run app5 idempotency — client_secret must be absent on re-run (AAP-80136)
       ansible.platform.application:
         name: "{{ name_prefix }}-app5"
         organization: "{{ org1.id }}"
@@ -208,7 +208,7 @@
         client_type: confidential
       register: app5_idem
 
-    - name: Assert app5 idempotent and no stale client_secret (AAP-801336)
+    - name: Assert app5 idempotent and no stale client_secret (AAP-80136)
       ansible.builtin.assert:
         that:
           - app5_idem is not changed

--- a/tests/integration/targets/applications_test/tasks/main.yml
+++ b/tests/integration/targets/applications_test/tasks/main.yml
@@ -190,10 +190,30 @@
         client_type: confidential
       register: app5
 
-    - name: Assert that we created application 5
+    - name: Assert that we created application 5 and client_secret returned
       ansible.builtin.assert:
         that:
           - app5 is changed
+          - app5.client_secret is defined
+          - app5.client_secret | length > 0
+          - app5.client_id is defined
+          - app5.client_id | length > 0
+        fail_msg: "confidential app create must return client_secret and client_id. app5={{ app5 }}"
+
+    - name: Re-run app5 idempotency — client_secret must be absent on re-run (AAP-801336)
+      ansible.platform.application:
+        name: "{{ name_prefix }}-app5"
+        organization: "{{ org1.id }}"
+        authorization_grant_type: password
+        client_type: confidential
+      register: app5_idem
+
+    - name: Assert app5 idempotent and no stale client_secret (AAP-801336)
+      ansible.builtin.assert:
+        that:
+          - app5_idem is not changed
+          - app5_idem.client_secret is not defined or app5_idem.client_secret == None
+        fail_msg: "Idempotent re-run must not expose stale client_secret. app5_idem={{ app5_idem }}"
 
     - name: Create Application 6
       ansible.platform.application:

--- a/tools/mock_gateway_server.py
+++ b/tools/mock_gateway_server.py
@@ -25,11 +25,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import secrets
 import threading
 import time
 from dataclasses import dataclass, field
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 from urllib.parse import parse_qs, urlparse
 
 
@@ -45,11 +46,21 @@ def _now_iso() -> str:
 class GenericResource:
     """Thread-safe CRUD store for any named resource."""
 
-    def __init__(self, resource_name: str, required_fields: Optional[List[str]] = None, start_id: int = 2000, patch_fields: Optional[List[str]] = None):
+    def __init__(
+        self,
+        resource_name: str,
+        required_fields: Optional[List[str]] = None,
+        start_id: int = 2000,
+        patch_fields: Optional[List[str]] = None,
+        post_only_fields: Optional[Dict[str, Callable[[], Any]]] = None,
+    ):
         self.lock = threading.Lock()
         self.resource_name = resource_name
         self.required_fields: List[str] = required_fields or []
         self.patch_fields: Optional[List[str]] = patch_fields  # None = allow all
+        # post_only_fields: generated on POST, returned in create response, never stored.
+        # Simulates API-generated secrets like client_secret that are only visible once.
+        self.post_only_fields: Dict[str, Callable[[], Any]] = post_only_fields or {}
         self._next_id = start_id
         self._items: Dict[int, Dict[str, Any]] = {}
 
@@ -68,7 +79,12 @@ class GenericResource:
             }
             item.update({k: v for k, v in payload.items() if v is not None})
             self._items[item_id] = item
-            return item
+            # post_only_fields are returned in the POST response but never stored.
+            # On GET/PATCH the fields will be absent, matching real Gateway behaviour.
+            response = dict(item)
+            for field_name, generator in self.post_only_fields.items():
+                response[field_name] = generator()
+            return response
 
     def list_items(self, filters: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
         with self.lock:
@@ -177,9 +193,18 @@ class Store:
 
     def _init_resources(self) -> None:
         """Create all generic resource stores with appropriate config."""
+        # Applications: client_secret returned on POST only, never on GET/PATCH.
+        self._resources["applications"] = GenericResource(
+            resource_name="applications",
+            required_fields=["name", "organization"],
+            start_id=3000,
+            post_only_fields={
+                "client_id": lambda: secrets.token_hex(16),
+                "client_secret": lambda: secrets.token_hex(32),
+            },
+        )
         defs: List[tuple] = [
             # (endpoint_name, required_fields, start_id)
-            ("applications", ["name", "organization"], 3000),
             ("authenticators", ["name"], 3100),
             ("authenticator_maps", ["name", "authenticator"], 3200),
             ("ca_certificates", ["name"], 3300),


### PR DESCRIPTION
 [AAP-80136] Fix application module to return clien_secret when app created


## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
- Why is this change needed?
- How does this change address the issue?

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment
- [ ] Existing playbook FQCNs are preserved (no renames without a redirect in `meta/routing.yml`)
- [ ] Deprecated parameters include a `deprecated:` block in `DOCUMENTATION` with removal version

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### CasC Notification
<!-- Required if this PR: adds a new module, changes aap_* auth params, changes RETURN structure, deprecates anything -->
<!-- See CONTRIBUTING.md §7 for the full trigger list and notification steps -->
- [ ] Not applicable — this change does not affect the CasC-monitored surface
- [ ] CasC Jira ticket created: <!-- link here -->
- [ ] CasC team tagged in this PR
- [ ] Migration guide provided (required for breaking changes)

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
