### PR TITLE
[AAP-70178] Add `reject_failed_basic_auth` route

### DIFF
--- a/plugins/modules/route.py
+++ b/plugins/modules/route.py
@@ -61,7 +61,7 @@ options:
       type: bool
     reject_failed_auth:
       description:
-        - If true this route will return a 401 instead of allowing unauthenticated requests to the back end.
+        - if true, requests with invalid basic credentials will receive a 401 instead of being passed to the back end as anonymous.
       type: bool
     service_path:
       description:

--- a/plugins/modules/route.py
+++ b/plugins/modules/route.py
@@ -59,6 +59,10 @@ options:
         - Flag whether or not the route is an internal route.
         - Internal routes are only accessible to other services.
       type: bool
+    reject_failed_auth:
+      description:
+        - If true this route will return a 401 instead of allowing unauthenticated requests to the back end.
+      type: bool
     service_path:
       description:
       - URL path on the AAP Service cluster to route traffic to

--- a/plugins/modules/route.py
+++ b/plugins/modules/route.py
@@ -61,7 +61,8 @@ options:
       type: bool
     reject_failed_auth:
       description:
-        - if true, requests with invalid basic credentials will receive a 401 instead of being passed to the back end as anonymous.
+        - If true, requests with invalid Basic credentials will receive a 401 instead of being passed to the back end as anonymous.
+        - Requests without credentials continue to be passed through anonymously.
       type: bool
     service_path:
       description:

--- a/plugins/modules/route.py
+++ b/plugins/modules/route.py
@@ -59,9 +59,9 @@ options:
         - Flag whether or not the route is an internal route.
         - Internal routes are only accessible to other services.
       type: bool
-    reject_failed_auth:
+    reject_failed_basic_auth:
       description:
-        - If true, requests with invalid Basic credentials will receive a 401 instead of being passed to the back end as anonymous.
+        - If true, requests with invalid Basic credentials will receive a 401 instead of being passed to the back end.
         - Requests without credentials continue to be passed through anonymously.
       type: bool
     service_path:

--- a/plugins/modules/service.py
+++ b/plugins/modules/service.py
@@ -52,7 +52,7 @@ options:
       type: bool
     reject_failed_auth:
       description:
-        - If true this route will return a 401 instead of allowing unauthenticated requests to the back end.
+        - if true, requests with invalid basic credentials will receive a 401 instead of being passed to the back end as anonymous.
       type: bool
     enable_gateway_auth:
       description: If false, the AAP gateway will not insert a gateway token into the proxied request

--- a/plugins/modules/service.py
+++ b/plugins/modules/service.py
@@ -52,7 +52,8 @@ options:
       type: bool
     reject_failed_auth:
       description:
-        - if true, requests with invalid basic credentials will receive a 401 instead of being passed to the back end as anonymous.
+        - If true, requests with invalid Basic credentials will receive a 401 instead of being passed to the back end as anonymous.
+        - Requests without credentials continue to be passed through anonymously.
       type: bool
     enable_gateway_auth:
       description: If false, the AAP gateway will not insert a gateway token into the proxied request

--- a/plugins/modules/service.py
+++ b/plugins/modules/service.py
@@ -50,6 +50,10 @@ options:
         - Flag whether or not the service is an internal route.
         - Internal routes are only accessible to other services.
       type: bool
+    reject_failed_auth:
+      description:
+        - If true this route will return a 401 instead of allowing unauthenticated requests to the back end.
+      type: bool
     enable_gateway_auth:
       description: If false, the AAP gateway will not insert a gateway token into the proxied request
       type: bool

--- a/plugins/modules/service.py
+++ b/plugins/modules/service.py
@@ -50,9 +50,9 @@ options:
         - Flag whether or not the service is an internal route.
         - Internal routes are only accessible to other services.
       type: bool
-    reject_failed_auth:
+    reject_failed_basic_auth:
       description:
-        - If true, requests with invalid Basic credentials will receive a 401 instead of being passed to the back end as anonymous.
+        - If true, requests with invalid Basic credentials will receive a 401 instead of being passed to the back end.
         - Requests without credentials continue to be passed through anonymously.
       type: bool
     enable_gateway_auth:

--- a/plugins/plugin_utils/ansible_models/route.py
+++ b/plugins/plugin_utils/ansible_models/route.py
@@ -23,7 +23,7 @@ class AnsibleRoute:
     enable_gateway_auth: Optional[bool] = True
     enable_mtls: Optional[bool] = False
     is_internal_route: Optional[bool] = None
-    reject_failed_auth: Optional[bool] = None
+    reject_failed_basic_auth: Optional[bool] = None
     service_path: Optional[str] = None
     service_port: Optional[int] = None
     node_tags: Optional[str] = None

--- a/plugins/plugin_utils/ansible_models/route.py
+++ b/plugins/plugin_utils/ansible_models/route.py
@@ -23,6 +23,7 @@ class AnsibleRoute:
     enable_gateway_auth: Optional[bool] = True
     enable_mtls: Optional[bool] = False
     is_internal_route: Optional[bool] = None
+    reject_failed_auth: Optional[bool] = None
     service_path: Optional[str] = None
     service_port: Optional[int] = None
     node_tags: Optional[str] = None

--- a/plugins/plugin_utils/ansible_models/service.py
+++ b/plugins/plugin_utils/ansible_models/service.py
@@ -21,7 +21,7 @@ class AnsibleService:
     service_cluster: Optional[Union[str, int]] = None
     is_service_https: Optional[bool] = False
     is_internal_route: Optional[bool] = None
-    reject_failed_auth: Optional[bool] = None
+    reject_failed_basic_auth: Optional[bool] = None
     enable_gateway_auth: Optional[bool] = True
     enable_mtls: Optional[bool] = False
     service_path: Optional[str] = None

--- a/plugins/plugin_utils/ansible_models/service.py
+++ b/plugins/plugin_utils/ansible_models/service.py
@@ -21,6 +21,7 @@ class AnsibleService:
     service_cluster: Optional[Union[str, int]] = None
     is_service_https: Optional[bool] = False
     is_internal_route: Optional[bool] = None
+    reject_failed_auth: Optional[bool] = None
     enable_gateway_auth: Optional[bool] = True
     enable_mtls: Optional[bool] = False
     service_path: Optional[str] = None

--- a/plugins/plugin_utils/api/v1/route.py
+++ b/plugins/plugin_utils/api/v1/route.py
@@ -25,6 +25,7 @@ class APIRoute_v1(BaseTransformMixin):
     enable_gateway_auth: Optional[bool] = None
     enable_mtls: Optional[bool] = None
     is_internal_route: Optional[bool] = None
+    reject_failed_basic_auth: Optional[bool] = None
     service_path: Optional[str] = None
     service_port: Optional[int] = None
     node_tags: Optional[str] = None
@@ -86,6 +87,7 @@ class RouteTransformMixin_v1(BaseTransformMixin):
             "enable_gateway_auth",
             "enable_mtls",
             "is_internal_route",
+            "reject_failed_basic_auth",
             "service_path",
             "service_port",
             "node_tags",
@@ -130,6 +132,7 @@ class RouteTransformMixin_v1(BaseTransformMixin):
             "enable_gateway_auth",
             "enable_mtls",
             "is_internal_route",
+            "reject_failed_basic_auth",
             "service_path",
             "service_port",
             "node_tags",
@@ -206,6 +209,7 @@ class RouteTransformMixin_v1(BaseTransformMixin):
             enable_gateway_auth=api_data.get("enable_gateway_auth"),
             enable_mtls=api_data.get("enable_mtls"),
             is_internal_route=api_data.get("is_internal_route"),
+            reject_failed_basic_auth=api_data.get("reject_failed_basic_auth"),
             service_path=api_data.get("service_path"),
             service_port=api_data.get("service_port"),
             node_tags=api_data.get("node_tags"),

--- a/plugins/plugin_utils/api/v1/service.py
+++ b/plugins/plugin_utils/api/v1/service.py
@@ -26,6 +26,7 @@ class APIService_v1(BaseTransformMixin):
     service_cluster: Optional[int] = None
     is_service_https: Optional[bool] = None
     is_internal_route: Optional[bool] = None
+    reject_failed_basic_auth: Optional[bool] = None
     enable_gateway_auth: Optional[bool] = None
     enable_mtls: Optional[bool] = None
     service_path: Optional[str] = None
@@ -90,6 +91,7 @@ class ServiceTransformMixin_v1(BaseTransformMixin):
             "description",
             "is_service_https",
             "is_internal_route",
+            "reject_failed_basic_auth",
             "enable_gateway_auth",
             "enable_mtls",
             "service_path",
@@ -145,6 +147,7 @@ class ServiceTransformMixin_v1(BaseTransformMixin):
             "service_cluster",
             "is_service_https",
             "is_internal_route",
+            "reject_failed_basic_auth",
             "enable_gateway_auth",
             "enable_mtls",
             "service_path",
@@ -223,6 +226,7 @@ class ServiceTransformMixin_v1(BaseTransformMixin):
             service_cluster=api_data.get("service_cluster"),
             is_service_https=api_data.get("is_service_https"),
             is_internal_route=api_data.get("is_internal_route"),
+            reject_failed_basic_auth=api_data.get("reject_failed_basic_auth"),
             enable_gateway_auth=api_data.get("enable_gateway_auth"),
             enable_mtls=api_data.get("enable_mtls"),
             service_path=api_data.get("service_path"),

--- a/tests/integration/targets/routes_test/tasks/main.yml
+++ b/tests/integration/targets/routes_test/tasks/main.yml
@@ -82,7 +82,7 @@
         service_path: "{{ item.service_path | default(omit) }}"
         service_port: "{{ item.service_port | default(omit) }}"
         node_tags: "{{ item.node_tags | default(omit) }}"
-        reject_failed_auth: "{{ item.reject_failed_auth | default(omit) }}"
+        reject_failed_basic_auth: "{{ item.reject_failed_basic_auth | default(omit) }}"
         state: present
       loop: "{{ gateway_routes }}"
       vars:
@@ -121,7 +121,7 @@
         service_path: "{{ item.service_path | default(omit) }}"
         service_port: "{{ item.service_port | default(omit) }}"
         node_tags: "{{ item.node_tags | default(omit) }}"
-        reject_failed_auth: "{{ item.reject_failed_auth | default(omit) }}"
+        reject_failed_basic_auth: "{{ item.reject_failed_basic_auth | default(omit) }}"
         state: present
       loop: "{{ gateway_routes }}"
       vars:
@@ -147,7 +147,7 @@
             service_cluster: "{{ test_id }}hub"
             service_path: '/ccc/v1/'
             service_port: 1111
-            reject_failed_auth: true
+            reject_failed_basic_auth: true
       register: __routes_result
 
     - name: Assert Create Routes tests passed
@@ -171,7 +171,7 @@
         service_path: "{{ item.service_path | default(omit) }}"
         service_port: "{{ item.service_port | default(omit) }}"
         node_tags: "{{ item.node_tags | default(omit) }}"
-        reject_failed_auth: "{{ item.reject_failed_auth | default(omit) }}"
+        reject_failed_basic_auth: "{{ item.reject_failed_basic_auth | default(omit) }}"
         state: "{{ item.state | default('present') }}"
       loop: "{{ gateway_routes }}"
       vars:
@@ -273,7 +273,7 @@
         service_path: "{{ item.service_path | default(omit) }}"
         service_port: "{{ item.service_port | default(omit) }}"
         node_tags: "{{ item.node_tags | default(omit) }}"
-        reject_failed_auth: "{{ item.reject_failed_auth | default(omit) }}"
+        reject_failed_basic_auth: "{{ item.reject_failed_basic_auth | default(omit) }}"
         state: "{{ item.state | default('present') }}"
       loop: "{{ gateway_routes }}"
       vars:
@@ -357,7 +357,7 @@
         service_path: "{{ item.service_path | default(omit) }}"
         service_port: "{{ item.service_port | default(omit) }}"
         node_tags: "{{ item.node_tags | default(omit) }}"
-        reject_failed_auth: "{{ item.reject_failed_auth | default(omit) }}"
+        reject_failed_basic_auth: "{{ item.reject_failed_basic_auth | default(omit) }}"
         state: absent
       loop: "{{ gateway_routes }}"
       vars:

--- a/tests/integration/targets/routes_test/tasks/main.yml
+++ b/tests/integration/targets/routes_test/tasks/main.yml
@@ -156,6 +156,7 @@
           - __routes_result.results[0] is changed
           - __routes_result.results[1] is changed
           - __routes_result.results[2] is changed
+          - __routes_result.results[2].reject_failed_basic_auth is true
 
     ### 2nd run for Routes ###
     - name: Check Routes Idempotency
@@ -195,6 +196,7 @@
           - name: "{{ test_id }}Hub Svc Route"
             gateway_path: '/hub-svc-1/'
             http_port: "{{ test_id }}Port 8050"
+            reject_failed_basic_auth: true
             state: exists
           # Check for existence, no changes
           - name: "{{ test_id }}Hub Svc Route"

--- a/tests/integration/targets/routes_test/tasks/main.yml
+++ b/tests/integration/targets/routes_test/tasks/main.yml
@@ -82,6 +82,7 @@
         service_path: "{{ item.service_path | default(omit) }}"
         service_port: "{{ item.service_port | default(omit) }}"
         node_tags: "{{ item.node_tags | default(omit) }}"
+        reject_failed_auth: "{{ item.reject_failed_auth | default(omit) }}"
         state: present
       loop: "{{ gateway_routes }}"
       vars:
@@ -120,6 +121,7 @@
         service_path: "{{ item.service_path | default(omit) }}"
         service_port: "{{ item.service_port | default(omit) }}"
         node_tags: "{{ item.node_tags | default(omit) }}"
+        reject_failed_auth: "{{ item.reject_failed_auth | default(omit) }}"
         state: present
       loop: "{{ gateway_routes }}"
       vars:
@@ -145,6 +147,7 @@
             service_cluster: "{{ test_id }}hub"
             service_path: '/ccc/v1/'
             service_port: 1111
+            reject_failed_auth: true
       register: __routes_result
 
     - name: Assert Create Routes tests passed
@@ -168,6 +171,7 @@
         service_path: "{{ item.service_path | default(omit) }}"
         service_port: "{{ item.service_port | default(omit) }}"
         node_tags: "{{ item.node_tags | default(omit) }}"
+        reject_failed_auth: "{{ item.reject_failed_auth | default(omit) }}"
         state: "{{ item.state | default('present') }}"
       loop: "{{ gateway_routes }}"
       vars:
@@ -269,6 +273,7 @@
         service_path: "{{ item.service_path | default(omit) }}"
         service_port: "{{ item.service_port | default(omit) }}"
         node_tags: "{{ item.node_tags | default(omit) }}"
+        reject_failed_auth: "{{ item.reject_failed_auth | default(omit) }}"
         state: "{{ item.state | default('present') }}"
       loop: "{{ gateway_routes }}"
       vars:
@@ -352,6 +357,7 @@
         service_path: "{{ item.service_path | default(omit) }}"
         service_port: "{{ item.service_port | default(omit) }}"
         node_tags: "{{ item.node_tags | default(omit) }}"
+        reject_failed_auth: "{{ item.reject_failed_auth | default(omit) }}"
         state: absent
       loop: "{{ gateway_routes }}"
       vars:


### PR DESCRIPTION
## Description
Add `reject_failed_basic_auth` field to the route module.
Requires: ansible/jewel#126
Issue: [AAP-70178](https://redhat.atlassian.net/browse/AAP-70178)


The gateway is adding a new boolean field `reject_failed_basic_auth` on routes (ansible/jewel#126). When enabled, the gateway returns a 401 immediately for invalid Basic auth credentials instead of silently passing the request through to the backend as anonymous.

This is needed to fix a bug where podman/docker login always reports "Login Succeeded" even with invalid credentials - because the gateway catches the `AuthenticationFailed` exception, falls through to anonymous (user = None) and the container registry's `/token/` endpoint issues an anonymous token instead of failing.

Changes:
- Added `reject_failed_basic_auth` option to the route module documentation
- Added `reject_failed_basic_auth` field to the AnsibleRoute dataclass
- Updated the integration test to exercise the new field

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test update

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment
- [x] Existing playbook FQCNs are preserved (no renames without a redirect in `meta/routing.yml`)
- [x] Deprecated parameters include a `deprecated:` block in `DOCUMENTATION` with removal version

### Required Actions
- [x] Requires downstream repository changes - ansible/jewel#126

### CasC Notification
<!-- Required if this PR: adds a new module, changes aap_* auth params, changes RETURN structure, deprecates anything -->
<!-- See CONTRIBUTING.md §7 for the full trigger list and notification steps -->
- [x] Not applicable — this change does not affect the CasC-monitored surface

### Testing Instructions:
1. Create a route with `reject_failed_basic_auth: true`
2. Verify the route is created with the field set
3. Re-run the same task and verify idempotency (no change)

### Expected Results
Route is created with `reject_failed_basic_auth=true`, idempotency passes.
