### PR TITLE
Allow fork PR checkout for pull_request_target integration workflows

### DIFF
--- a/.github/workflows/casc-notify-check.yml
+++ b/.github/workflows/casc-notify-check.yml
@@ -22,10 +22,12 @@ jobs:
     name: Check CasC notification requirement
     runs-on: ubuntu-latest
     steps:
+      # Required for fork PRs under pull_request_target (reads PR files only; no secrets execution path).
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
 
       - name: Get list of changed files
         id: changed-files

--- a/.github/workflows/integration-stable-2.6.yml
+++ b/.github/workflows/integration-stable-2.6.yml
@@ -28,10 +28,12 @@ jobs:
     if: ${{ !github.event.pull_request || contains(github.event.pull_request.labels.*.name, 'safe to test') }}
 
     steps:
+      # Required for fork PRs under pull_request_target; gated by "safe to test" label.
       - uses: actions/checkout@v3
         with:
           path: ansible-platform
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Checkout aap-gateway (use a branch is specified) and optionally DAB
         env:
@@ -84,10 +86,12 @@ jobs:
       HEADLESS: "yes"
     if: ${{ !github.event.pull_request || contains(github.event.pull_request.labels.*.name, 'safe to test') }}
     steps:
+      # Required for fork PRs under pull_request_target; gated by "safe to test" label.
       - uses: actions/checkout@v3
         with:
           path: ansible-platform
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Checkout aap-gateway (use a branch is specified) and optionally DAB
         env:
@@ -125,10 +129,12 @@ jobs:
       HEADLESS: "yes"
     if: ${{ !github.event.pull_request || contains(github.event.pull_request.labels.*.name, 'safe to test') }}
     steps:
+      # Required for fork PRs under pull_request_target; gated by "safe to test" label.
       - uses: actions/checkout@v3
         with:
           path: ansible-platform
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Checkout aap-gateway (use a branch is specified) and optionally DAB
         env:

--- a/.github/workflows/integration-stable-2.7.yml
+++ b/.github/workflows/integration-stable-2.7.yml
@@ -36,10 +36,12 @@ jobs:
           - http-persistent
 
     steps:
+      # Required for fork PRs under pull_request_target; gated by "safe to test" label.
       - uses: actions/checkout@v3
         with:
           path: ansible-platform
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Checkout aap-gateway (use a branch is specified) and optionally DAB
         env:
@@ -101,10 +103,12 @@ jobs:
       HEADLESS: "yes"
     if: ${{ !github.event.pull_request || contains(github.event.pull_request.labels.*.name, 'safe to test') }}
     steps:
+      # Required for fork PRs under pull_request_target; gated by "safe to test" label.
       - uses: actions/checkout@v3
         with:
           path: ansible-platform
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Checkout aap-gateway (use a branch is specified) and optionally DAB
         env:
@@ -145,10 +149,12 @@ jobs:
       HEADLESS: "yes"
     if: ${{ !github.event.pull_request || contains(github.event.pull_request.labels.*.name, 'safe to test') }}
     steps:
+      # Required for fork PRs under pull_request_target; gated by "safe to test" label.
       - uses: actions/checkout@v3
         with:
           path: ansible-platform
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Checkout aap-gateway (use a branch is specified) and optionally DAB
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,10 +38,12 @@ jobs:
           - http-persistent
 
     steps:
+      # Required for fork PRs under pull_request_target; gated by "safe to test" label.
       - uses: actions/checkout@v3
         with:
           path: ansible-platform
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Checkout aap-gateway (use a branch is specified) and optionally DAB
         env:
@@ -103,10 +105,12 @@ jobs:
       HEADLESS: "yes"
     if: ${{ !github.event.pull_request || contains(github.event.pull_request.labels.*.name, 'safe to test') }}
     steps:
+      # Required for fork PRs under pull_request_target; gated by "safe to test" label.
       - uses: actions/checkout@v3
         with:
           path: ansible-platform
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Checkout aap-gateway (use a branch is specified) and optionally DAB
         env:
@@ -147,10 +151,12 @@ jobs:
       HEADLESS: "yes"
     if: ${{ !github.event.pull_request || contains(github.event.pull_request.labels.*.name, 'safe to test') }}
     steps:
+      # Required for fork PRs under pull_request_target; gated by "safe to test" label.
       - uses: actions/checkout@v3
         with:
           path: ansible-platform
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Checkout aap-gateway (use a branch is specified) and optionally DAB
         env:


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
GitHub now blocks actions/checkout of fork PR heads under
pull_request_target unless allow-unsafe-pr-checkout is set.
Opt in so integration CI can run after the safe to test label.

- Why is this change needed?
Fork PRs (e.g. #214) fail at checkout with:
`Refusing to check out fork pull request code from a 'pull_request_target' workflow`
Integration still requires `pull_request_target` for secrets and remains gated by the `safe to test` label.

- How does this change address the issue?
Add `allow-unsafe-pr-checkout: true` to checkouts that use `github.event.pull_request.head.sha` under `pull_request_target`
Covers `integration.yml`, `integration-stable-2.7.yml`, `integration-stable-2.6.yml`, and `casc-notify-check.yml`
Restores fork PR integration CI after GitHub's July 2026 `actions/checkout` security change
## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change

## Self-Review Checklist
<!-- These items help ensure quality - they complement our automated CI checks -->
- [ ] I have performed a self-review of my code
- [ ] I have added relevant comments to complex code sections
- [ ] I have updated documentation where needed
- [ ] I have considered the security impact of these changes
- [ ] I have considered performance implications
- [ ] I have thought about error handling and edge cases
- [ ] I have tested the changes in my local environment
- [ ] Existing playbook FQCNs are preserved (no renames without a redirect in `meta/routing.yml`)
- [ ] Deprecated parameters include a `deprecated:` block in `DOCUMENTATION` with removal version

## Testing Instructions
<!-- Optional for test-only changes. Mandatory for all other changes -->
<!-- Must be detailed enough for reviewers to reproduce -->
### Prerequisites
<!-- List any specific setup required -->

### Steps to Test
1. 
2. 
3. 

### Expected Results
<!-- Describe what should happen after following the steps -->

## Additional Context
<!-- Optional but helpful information -->

### Required Actions
<!-- Check if changes require work in other areas -->
<!-- Remove section if no external actions needed -->
- [ ] Requires documentation updates
  <!-- API docs, feature docs, deployment guides -->
- [ ] Requires downstream repository changes
  <!-- Specify repos: django-ansible-base, eda-server, etc. -->
- [ ] Requires infrastructure/deployment changes
  <!-- CI/CD, installer updates, new services -->
- [ ] Requires coordination with other teams
  <!-- UI team, platform services, infrastructure -->
- [ ] Blocked by PR/MR: #XXX
  <!-- Reference blocking PRs/MRs with brief context -->

### CasC Notification
<!-- Required if this PR: adds a new module, changes aap_* auth params, changes RETURN structure, deprecates anything -->
<!-- See CONTRIBUTING.md §7 for the full trigger list and notification steps -->
- [ ] Not applicable — this change does not affect the CasC-monitored surface
- [ ] CasC Jira ticket created: <!-- link here -->
- [ ] CasC team tagged in this PR
- [ ] Migration guide provided (required for breaking changes)

### Screenshots/Logs
<!-- Add if relevant to demonstrate the changes -->
