### PR TITLE
[stable-2.7] backport: Add pkce_required parameter to application module (#219)

### DIFF
--- a/plugins/modules/application.py
+++ b/plugins/modules/application.py
@@ -76,6 +76,11 @@ options:
       default: "present"
       choices: ["present", "absent", "exists", "enforced"]
       type: str
+    pkce_required:
+      description:
+        - When True, clients must use PKCE (send code_challenge) when requesting authorization codes for this application.
+      type: bool
+      default: true
     skip_authorization:
       description:
         - Set True to skip authorization step for completely trusted applications.

--- a/plugins/plugin_utils/ansible_models/application.py
+++ b/plugins/plugin_utils/ansible_models/application.py
@@ -27,6 +27,7 @@ class AnsibleApplication:
     redirect_uris: Optional[Union[str, List[str]]] = None
     post_logout_redirect_uris: Optional[Union[str, List[str]]] = None
 
+    pkce_required: Optional[bool] = None
     skip_authorization: Optional[bool] = None
     app_url: Optional[str] = None
 

--- a/plugins/plugin_utils/api/v1/application.py
+++ b/plugins/plugin_utils/api/v1/application.py
@@ -26,6 +26,7 @@ class APIApplication_v1(BaseTransformMixin):
     redirect_uris: Optional[str] = None
     post_logout_redirect_uris: Optional[str] = None
 
+    pkce_required: Optional[bool] = None
     skip_authorization: Optional[bool] = None
     app_url: Optional[str] = None
 
@@ -103,6 +104,7 @@ class ApplicationTransformMixin_v1(BaseTransformMixin):
             "algorithm",
             "authorization_grant_type",
             "client_type",
+            "pkce_required",
             "skip_authorization",
             "app_url",
         ):
@@ -153,6 +155,7 @@ class ApplicationTransformMixin_v1(BaseTransformMixin):
             "client_type",
             "redirect_uris",
             "post_logout_redirect_uris",
+            "pkce_required",
             "skip_authorization",
             "app_url",
             "user",
@@ -237,6 +240,7 @@ class ApplicationTransformMixin_v1(BaseTransformMixin):
             client_type=api_data.get("client_type"),
             redirect_uris=api_data.get("redirect_uris"),
             post_logout_redirect_uris=api_data.get("post_logout_redirect_uris"),
+            pkce_required=api_data.get("pkce_required"),
             skip_authorization=api_data.get("skip_authorization"),
             app_url=api_data.get("app_url"),
             user=api_data.get("user"),


### PR DESCRIPTION
This is a backport of https://github.com/ansible/ansible.platform/pull/219 to stable-2.7

## Description
- **What is being changed?**
  - Added `pkce_required` boolean parameter to the `application` module documentation (`plugins/modules/application.py`)
  - Added `pkce_required` field to the `AnsibleApplication` dataclass (`plugins/plugin_utils/ansible_models/application.py`)

- **Why is this change needed?**
  - django-ansible-base [PR #1051](https://github.com/ansible/django-ansible-base/pull/1051) added a `pkce_required` boolean field to the `OAuth2Application` model. Without this collection update, the `collection-test-completeness` check in aap-gateway CI fails because the API exposes `pkce_required` but the collection module doesn't declare it.

- **How does this change address the issue?**
  - The completeness test compares API POST fields against module documentation options. Adding `pkce_required` to both the module docs and the dataclass resolves the "Failed, option mismatch" for the `application` module.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Self-Review Checklist
- [x] I have performed a self-review of my code
- [x] I have added relevant comments to complex code sections
- [x] I have updated documentation where needed
- [x] I have considered the security impact of these changes
- [x] I have considered performance implications
- [x] I have thought about error handling and edge cases
- [x] I have tested the changes in my local environment
- [x] Existing playbook FQCNs are preserved (no renames without a redirect in `meta/routing.yml`)
- [x] Deprecated parameters include a `deprecated:` block in `DOCUMENTATION` with removal version

## Testing Instructions
### Prerequisites
- AAP Gateway dev environment running with latest django-ansible-base (includes PR #1051)

### Steps to Test
1. Run `make collection-test-completeness` from the `ansible.platform` directory
2. Verify the `application` module no longer shows "Failed, option mismatch" for `pkce_required`

### Expected Results
- The completeness test passes for the `application` module
- `pkce_required` shows as "OK" in the completeness report

## Additional Context

### Required Actions
- [x] Not applicable — this change does not affect the CasC-monitored surface

---
**Note:** This PR was developed with assistance from Claude AI assistant.