### PR TITLE
[stable-2.7] Backport - gateway_api doc updates + FIPS Compliance to ensure we use sha256 instead of md5 + reject_failed_basic_auth route update

### DIFF
--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -27,6 +27,8 @@ sections:
     - Bugfixes
   - - known_issues
     - Known Issues
+  - - doc_changes
+    - Documentation Changes
 title: ansible.platform
 trivial_section_name: trivial
 use_fqcn: true

--- a/changelogs/fragments/gateway_api_doc_change.yml
+++ b/changelogs/fragments/gateway_api_doc_change.yml
@@ -1,0 +1,4 @@
+---
+doc_changes:
+  - gateway_api - update documentation for the gateway_api lookup plugin to
+    reflect the new functionality and usage. Additionally add and update examples.

--- a/plugins/connection/http.py
+++ b/plugins/connection/http.py
@@ -198,7 +198,7 @@ class Connection(ConnectionBase):
             import hashlib
             import time
 
-            host_hash = hashlib.md5(inventory_hostname.encode()).hexdigest()[:4]
+            host_hash = hashlib.sha256(inventory_hostname.encode()).hexdigest()[:4]
             # Include a per-invocation suffix so loop iterations on the same host
             # each get a unique socket path. Without this, iteration N+1 spawns a
             # new manager at the same path as iteration N, but the action plugin

--- a/plugins/lookup/gateway_api.py
+++ b/plugins/lookup/gateway_api.py
@@ -11,15 +11,18 @@ short_description: Search the API for objects
 requirements:
   - None
 description:
-  - Returns GET requests from the Automation Platform Gateway API. See
-    U(https://docs.ansible.com/TODO) for API usage.
-  - This plugin is designed to support Gateway API endpoints used to manage resources with ansible.platform modules,
-    such as users, teams, organizations, settings, role_definitions, and related endpoints.
-  - Querying APIs outside of the Gateway API (such as Automation Hub, Galaxy etc.) is not supported and may lead to unexpected errors.
+  - Query Ansible Automation Platform component API endpoints via the Platform Gateway.
+  - Supports pagination (C(return_all)), filtering (C(query_params)), and returning full objects (C(return_objects)) or IDs (C(return_ids)).
+  - Use for read-only lookups of users, teams, organizations, settings, and other resources managed by C(ansible.platform) modules.
+  - By default, endpoints are resolved against the Gateway API. For example, C(users) queries C(/api/gateway/v1/users/).
+  - To query other AAP components through the gateway, provide the full API path, such as C(api/eda/v1/decision-environments/) for Event-Driven Ansible.
+  - The Automation Controller, Platform Gateway, Event-Driven Ansible, and Galaxy APIs can all be queried through the gateway.
 options:
   _terms:
     description:
-      - The endpoint to query, i.e. teams, users, tokens, settings, services, etc.
+      - The API endpoint to query.
+      - For Gateway resources, provide a short path relative to the Gateway API (for example, C(users), C(teams), C(settings/notification)).
+      - For other AAP components, provide the full path through the gateway (for example, C(api/eda/v1/decision-environments/)).
     required: True
   query_params:
     description:
@@ -77,13 +80,13 @@ _raw:
 """
 
 EXAMPLES = """
-- name: Load the UI settings
+- name: Load notification settings
   set_fact:
-    ui_settings: "{{ lookup('ansible.platform.gateway_api', 'settings/ui') }}"
+    notification_settings: "{{ lookup('ansible.platform.gateway_api', 'settings/notification') }}"
 
-- name: Load the UI settings specifying the connection info
+- name: Load the notification settings specifying the connection info
   set_fact:
-    ui_settings: "{{ lookup('ansible.platform.gateway_api', 'settings/ui', host='gateway.example.com',
+    notification_settings: "{{ lookup('ansible.platform.gateway_api', 'settings/notification', host='gateway.example.com',
                              username='admin', password=my_pass_var, verify_ssl=False) }}"
 
 - name: Report the usernames of all users with admin privs
@@ -117,6 +120,11 @@ EXAMPLES = """
             query_params={ 'name__startswith' : 'foo', },
         ) | map(attribute='name') | list }}
   register: group_creation
+
+- name: List organziation information in EDA via the gateway
+  set_fact:
+    eda_organizations: "{{ lookup('ansible.platform.gateway_api', 'api/eda/v1/organizations', host='gateway.example.com',
+                             username='admin', password=my_pass_var, verify_ssl=False) }}"
 ...
 """
 

--- a/plugins/modules/route.py
+++ b/plugins/modules/route.py
@@ -59,6 +59,11 @@ options:
         - Flag whether or not the route is an internal route.
         - Internal routes are only accessible to other services.
       type: bool
+    reject_failed_basic_auth:
+      description:
+        - If true, requests with invalid Basic credentials will receive a 401 instead of being passed to the back end.
+        - Requests without credentials continue to be passed through anonymously.
+      type: bool
     service_path:
       description:
       - URL path on the AAP Service cluster to route traffic to

--- a/plugins/modules/service.py
+++ b/plugins/modules/service.py
@@ -50,6 +50,11 @@ options:
         - Flag whether or not the service is an internal route.
         - Internal routes are only accessible to other services.
       type: bool
+    reject_failed_basic_auth:
+      description:
+        - If true, requests with invalid Basic credentials will receive a 401 instead of being passed to the back end.
+        - Requests without credentials continue to be passed through anonymously.
+      type: bool
     enable_gateway_auth:
       description: If false, the AAP gateway will not insert a gateway token into the proxied request
       type: bool

--- a/plugins/plugin_utils/ansible_models/route.py
+++ b/plugins/plugin_utils/ansible_models/route.py
@@ -23,6 +23,7 @@ class AnsibleRoute:
     enable_gateway_auth: Optional[bool] = True
     enable_mtls: Optional[bool] = False
     is_internal_route: Optional[bool] = None
+    reject_failed_basic_auth: Optional[bool] = None
     service_path: Optional[str] = None
     service_port: Optional[int] = None
     node_tags: Optional[str] = None

--- a/plugins/plugin_utils/ansible_models/service.py
+++ b/plugins/plugin_utils/ansible_models/service.py
@@ -21,6 +21,7 @@ class AnsibleService:
     service_cluster: Optional[Union[str, int]] = None
     is_service_https: Optional[bool] = False
     is_internal_route: Optional[bool] = None
+    reject_failed_basic_auth: Optional[bool] = None
     enable_gateway_auth: Optional[bool] = True
     enable_mtls: Optional[bool] = False
     service_path: Optional[str] = None

--- a/plugins/plugin_utils/api/v1/route.py
+++ b/plugins/plugin_utils/api/v1/route.py
@@ -25,6 +25,7 @@ class APIRoute_v1(BaseTransformMixin):
     enable_gateway_auth: Optional[bool] = None
     enable_mtls: Optional[bool] = None
     is_internal_route: Optional[bool] = None
+    reject_failed_basic_auth: Optional[bool] = None
     service_path: Optional[str] = None
     service_port: Optional[int] = None
     node_tags: Optional[str] = None
@@ -86,6 +87,7 @@ class RouteTransformMixin_v1(BaseTransformMixin):
             "enable_gateway_auth",
             "enable_mtls",
             "is_internal_route",
+            "reject_failed_basic_auth",
             "service_path",
             "service_port",
             "node_tags",
@@ -130,6 +132,7 @@ class RouteTransformMixin_v1(BaseTransformMixin):
             "enable_gateway_auth",
             "enable_mtls",
             "is_internal_route",
+            "reject_failed_basic_auth",
             "service_path",
             "service_port",
             "node_tags",
@@ -206,6 +209,7 @@ class RouteTransformMixin_v1(BaseTransformMixin):
             enable_gateway_auth=api_data.get("enable_gateway_auth"),
             enable_mtls=api_data.get("enable_mtls"),
             is_internal_route=api_data.get("is_internal_route"),
+            reject_failed_basic_auth=api_data.get("reject_failed_basic_auth"),
             service_path=api_data.get("service_path"),
             service_port=api_data.get("service_port"),
             node_tags=api_data.get("node_tags"),

--- a/plugins/plugin_utils/api/v1/service.py
+++ b/plugins/plugin_utils/api/v1/service.py
@@ -26,6 +26,7 @@ class APIService_v1(BaseTransformMixin):
     service_cluster: Optional[int] = None
     is_service_https: Optional[bool] = None
     is_internal_route: Optional[bool] = None
+    reject_failed_basic_auth: Optional[bool] = None
     enable_gateway_auth: Optional[bool] = None
     enable_mtls: Optional[bool] = None
     service_path: Optional[str] = None
@@ -90,6 +91,7 @@ class ServiceTransformMixin_v1(BaseTransformMixin):
             "description",
             "is_service_https",
             "is_internal_route",
+            "reject_failed_basic_auth",
             "enable_gateway_auth",
             "enable_mtls",
             "service_path",
@@ -145,6 +147,7 @@ class ServiceTransformMixin_v1(BaseTransformMixin):
             "service_cluster",
             "is_service_https",
             "is_internal_route",
+            "reject_failed_basic_auth",
             "enable_gateway_auth",
             "enable_mtls",
             "service_path",
@@ -223,6 +226,7 @@ class ServiceTransformMixin_v1(BaseTransformMixin):
             service_cluster=api_data.get("service_cluster"),
             is_service_https=api_data.get("is_service_https"),
             is_internal_route=api_data.get("is_internal_route"),
+            reject_failed_basic_auth=api_data.get("reject_failed_basic_auth"),
             enable_gateway_auth=api_data.get("enable_gateway_auth"),
             enable_mtls=api_data.get("enable_mtls"),
             service_path=api_data.get("service_path"),

--- a/plugins/plugin_utils/manager/process_manager.py
+++ b/plugins/plugin_utils/manager/process_manager.py
@@ -377,7 +377,7 @@ def spawn_ephemeral_client(task_vars, gateway_config, task_env=None):
         return (client, None)
 
     inventory_hostname = task_vars.get("inventory_hostname", "localhost")
-    host_hash = hashlib.md5(inventory_hostname.encode()).hexdigest()[:4]
+    host_hash = hashlib.sha256(inventory_hostname.encode()).hexdigest()[:4]
 
     # Use a per-invocation time suffix so each ephemeral manager gets a UNIQUE
     # socket path.  Without this, orphaned managers from prior tasks (which are

--- a/tests/integration/targets/routes_test/tasks/main.yml
+++ b/tests/integration/targets/routes_test/tasks/main.yml
@@ -154,6 +154,7 @@
         service_path: "{{ item.service_path | default(omit) }}"
         service_port: "{{ item.service_port | default(omit) }}"
         node_tags: "{{ item.node_tags | default(omit) }}"
+        reject_failed_basic_auth: "{{ item.reject_failed_basic_auth | default(omit) }}"
         state: present
       loop: "{{ gateway_routes }}"
       vars:
@@ -199,6 +200,7 @@
         service_path: "{{ item.service_path | default(omit) }}"
         service_port: "{{ item.service_port | default(omit) }}"
         node_tags: "{{ item.node_tags | default(omit) }}"
+        reject_failed_basic_auth: "{{ item.reject_failed_basic_auth | default(omit) }}"
         state: present
       loop: "{{ gateway_routes }}"
       vars:
@@ -224,6 +226,7 @@
             service_cluster: "{{ test_id }}hub"
             service_path: '/ccc/v1/'
             service_port: 1111
+            reject_failed_basic_auth: true
       register: __routes_result
 
     - name: Assert Create Routes tests passed
@@ -232,6 +235,7 @@
           - __routes_result.results[0] is changed
           - __routes_result.results[1] is changed
           - __routes_result.results[2] is changed
+          - __routes_result.results[2].reject_failed_basic_auth is true
 
     ### 2nd run for Routes ###
     - name: Check Routes Idempotency
@@ -247,6 +251,7 @@
         service_path: "{{ item.service_path | default(omit) }}"
         service_port: "{{ item.service_port | default(omit) }}"
         node_tags: "{{ item.node_tags | default(omit) }}"
+        reject_failed_basic_auth: "{{ item.reject_failed_basic_auth | default(omit) }}"
         state: "{{ item.state | default('present') }}"
       loop: "{{ gateway_routes }}"
       vars:
@@ -270,6 +275,7 @@
           - name: "{{ test_id }}Hub Svc Route"
             gateway_path: '/hub-svc-1/'
             http_port: "{{ test_id }}Port 8050"
+            reject_failed_basic_auth: true
             state: exists
           # Check for existence, no changes
           - name: "{{ test_id }}Hub Svc Route"
@@ -348,6 +354,7 @@
         service_path: "{{ item.service_path | default(omit) }}"
         service_port: "{{ item.service_port | default(omit) }}"
         node_tags: "{{ item.node_tags | default(omit) }}"
+        reject_failed_basic_auth: "{{ item.reject_failed_basic_auth | default(omit) }}"
         state: "{{ item.state | default('present') }}"
       loop: "{{ gateway_routes }}"
       vars:
@@ -439,6 +446,7 @@
         service_path: "{{ item.service_path | default(omit) }}"
         service_port: "{{ item.service_port | default(omit) }}"
         node_tags: "{{ item.node_tags | default(omit) }}"
+        reject_failed_basic_auth: "{{ item.reject_failed_basic_auth | default(omit) }}"
         state: absent
       loop: "{{ gateway_routes }}"
       vars:

--- a/tests/unit/plugins/connection/test_http.py
+++ b/tests/unit/plugins/connection/test_http.py
@@ -349,3 +349,80 @@ def test_persistent_socket_file_missing_spawns_new():
     # Implementation stores manager info in a .meta file rather than ansible_facts.
     assert facts is None
     mock_pm.spawn_manager_process.assert_called_once()
+
+
+# ---- FIPS compliance ----
+
+
+def test_direct_mode_uses_sha256_for_host_hash():
+    """Direct mode uses SHA-256 (FIPS-compliant) instead of MD5 for host hash generation."""
+    import hashlib
+    from unittest.mock import mock_open
+
+    conn = _make_connection()
+    task_vars = {"inventory_hostname": "test-host"}
+    gateway_config = _make_gateway_config()
+
+    # Expected SHA-256 hash (first 4 chars)
+    expected_hash = hashlib.sha256("test-host".encode()).hexdigest()[:4]
+
+    with patch("ansible_collections.ansible.platform.plugins.connection.http.Path") as mock_path_cls:
+        mock_path_cls.return_value.exists.return_value = True
+        mock_path_cls.return_value.parent.parent.__truediv__.return_value.exists.return_value = True
+
+        with patch("ansible_collections.ansible.platform.plugins.connection.http.ProcessManager") as mock_pm:
+            mock_conn_info = MagicMock()
+            mock_conn_info.socket_path = "/tmp/test.sock"
+            mock_conn_info.authkey = b"test"
+            mock_conn_info.authkey_b64 = "dGVzdA=="
+            mock_pm.generate_connection_info.return_value = mock_conn_info
+            mock_pm.spawn_manager_process.return_value = MagicMock(pid=12345)
+            mock_pm.wait_for_process_startup.return_value = None
+
+            with patch("ansible_collections.ansible.platform.plugins.connection.http.ManagerRPCClient") as mock_rpc:
+                mock_rpc.return_value = MagicMock()
+                with patch("builtins.open", mock_open()):
+                    conn._get_direct_client(task_vars, gateway_config)
+
+                # Verify generate_connection_info was called with identifier containing SHA-256 hash
+                call_args = mock_pm.generate_connection_info.call_args
+                identifier = call_args.kwargs.get("identifier") if call_args else None
+                assert identifier is not None
+                assert identifier.startswith(f"e{expected_hash}")
+
+
+def test_spawn_ephemeral_uses_sha256_for_host_hash():
+    """spawn_ephemeral_client uses SHA-256 (FIPS-compliant) instead of MD5 for host hash."""
+    import hashlib
+
+    from ansible_collections.ansible.platform.plugins.plugin_utils.manager.process_manager import spawn_ephemeral_client
+
+    task_vars = {"inventory_hostname": "test-host"}
+    gateway_config = _make_gateway_config()
+
+    # Expected SHA-256 hash (first 4 chars)
+    expected_hash = hashlib.sha256("test-host".encode()).hexdigest()[:4]
+
+    with patch("ansible_collections.ansible.platform.plugins.plugin_utils.manager.process_manager._af_unix_available", return_value=True):
+        with patch("ansible_collections.ansible.platform.plugins.plugin_utils.manager.process_manager.Path") as mock_path:
+            mock_path.return_value.exists.return_value = True
+            mock_path.return_value.mkdir.return_value = None
+
+            with patch("ansible_collections.ansible.platform.plugins.plugin_utils.manager.process_manager.ProcessManager") as mock_pm:
+                mock_conn_info = MagicMock()
+                mock_conn_info.socket_path = "/tmp/test.sock"
+                mock_conn_info.authkey = b"test"
+                mock_conn_info.authkey_b64 = "dGVzdA=="
+                mock_pm.generate_connection_info.return_value = mock_conn_info
+                mock_pm.spawn_manager_process.return_value = MagicMock(pid=12345)
+                mock_pm.wait_for_process_startup.return_value = None
+
+                with patch("ansible_collections.ansible.platform.plugins.plugin_utils.manager.rpc_client.ManagerRPCClient") as mock_rpc:
+                    mock_rpc.return_value = MagicMock()
+                    client, _facts = spawn_ephemeral_client(task_vars, gateway_config)
+
+                    # Verify generate_connection_info was called with identifier containing SHA-256 hash
+                    call_args = mock_pm.generate_connection_info.call_args
+                    identifier = call_args.kwargs.get("identifier") if call_args else None
+                    assert identifier is not None
+                    assert identifier.startswith(f"e{expected_hash}")


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
Backport fix of changes already merged into devel - https://github.com/ansible/ansible.platform/pull/212 & https://github.com/ansible/ansible.platform/pull/208 & https://github.com/ansible/ansible.platform/pull/214

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change