### PR TITLE
[stable-2.7] - Backport - Update gateway_api lookup plugin to ensure ephemeral manager process is shut down

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ venv.bak/
 *.code-workspace
 *.vscode/
 .DS_Store
+.tokensave
 
 changelogs/.plugin-cache.yaml
 

--- a/changelogs/fragments/gateway_api_shutdown.yml
+++ b/changelogs/fragments/gateway_api_shutdown.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - gateway_api - Update the lookup plugin to ensure the ephemeral
+    manager processes getting spawned are terminated/killed.
+...

--- a/plugins/lookup/gateway_api.py
+++ b/plugins/lookup/gateway_api.py
@@ -231,9 +231,22 @@ class LookupModule(LookupBase):
             raise AnsibleError("gateway_api lookup: API request failed for '{0}': {1}".format(endpoint, to_native(e)))
         finally:
             try:
-                client.shutdown_manager()
-            except Exception:
-                pass
+                result = client.shutdown_manager()
+                self._display.vvvv("gateway_api: shutdown signal sent to manager: %s" % result)
+            except Exception as e:
+                self._display.vvvv("gateway_api: shutdown RPC failed (manager may have already exited): %s" % e)
+            try:
+                from ansible_collections.ansible.platform.plugins.plugin_utils.manager.process_manager import ProcessManager
+
+                ProcessManager.terminate_manager_process(getattr(client, "_process", None))
+                self._display.vvvv("gateway_api: manager process terminated")
+            except Exception as e:
+                self._display.warning("gateway_api: failed to terminate manager process: %s" % e)
+            try:
+                client.close()
+                self._display.vvvv("gateway_api: client connection closed")
+            except Exception as e:
+                self._display.vvvv("gateway_api: error closing client connection: %s" % e)
 
         # --- response validation ---
         if self.get_option("expect_objects") or self.get_option("expect_one"):

--- a/plugins/plugin_utils/manager/process_manager.py
+++ b/plugins/plugin_utils/manager/process_manager.py
@@ -156,6 +156,33 @@ class ProcessManager:
             return False
 
     @staticmethod
+    def terminate_manager_process(process, timeout: int = 5) -> None:
+        """
+        Terminate a manager subprocess: SIGTERM first, escalate to SIGKILL if needed.
+
+        Args:
+            process: subprocess.Popen object (or any object with poll/terminate/kill/wait).
+                     No-op if None or already exited.
+            timeout: Seconds to wait for graceful exit before sending SIGKILL.
+        """
+        if process is None or process.poll() is not None:
+            return
+        try:
+            process.terminate()
+            process.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=timeout)
+        except Exception as e:
+            logger.debug("Error terminating manager process: %s", e)
+            try:
+                if process.poll() is None:
+                    process.kill()
+                    process.wait(timeout=timeout)
+            except Exception:
+                pass
+
+    @staticmethod
     def cleanup_old_socket(socket_path: str) -> None:
         """
         Clean up an old socket file and its companion .meta file if they exist.
@@ -420,5 +447,6 @@ def spawn_ephemeral_client(task_vars, gateway_config, task_env=None):
     client = ManagerRPCClient(gateway_config.base_url, socket_path, authkey)
     client._ephemeral = True
     client.socket_path = socket_path
+    client._process = process
     logger.info("Ephemeral manager spawned for connection: local at %s", gateway_config.base_url)
     return (client, None)

--- a/tests/integration/targets/lookup_test/tasks/main.yml
+++ b/tests/integration/targets/lookup_test/tasks/main.yml
@@ -70,6 +70,7 @@
       ansible.builtin.shell: |
         pgrep -c -f manager_process[.]py || echo 0
       register: manager_proc_baseline
+      delegate_to: localhost
       changed_when: false
 
     - name: Use lookup plugin to query created objects
@@ -145,6 +146,7 @@
       ansible.builtin.shell: |
         pgrep -c -f manager_process[.]py || echo 0
       register: manager_proc_count
+      delegate_to: localhost
       changed_when: false
 
     - name: Assert no new manager processes are lingering after lookups

--- a/tests/integration/targets/lookup_test/tasks/main.yml
+++ b/tests/integration/targets/lookup_test/tasks/main.yml
@@ -63,6 +63,15 @@
         user: "{{ admin1.user.id }}"
         object_id: "{{ org1.organization.id }}"
 
+    # Baseline: count manager processes already running (persistent managers from
+    # the action module tasks above stay alive until play_end and must not skew
+    # the assertion below).
+    - name: Count manager_process.py subprocesses before lookups (baseline)
+      ansible.builtin.shell: |
+        pgrep -c -f manager_process[.]py || echo 0
+      register: manager_proc_baseline
+      changed_when: false
+
     - name: Use lookup plugin to query created objects
       ansible.builtin.set_fact:
         _org2: >-
@@ -127,6 +136,31 @@
         that:
           - expect_one is failed
           - "'Expected one object from endpoint users, but obtained 3 from API' in expect_one.msg"
+
+    # Verify ephemeral manager processes spawned by gateway_api lookups are
+    # cleaned up immediately after each call (not left running until play end).
+    # Compared against the baseline taken before the lookups so that persistent
+    # managers from the action module tasks above don't produce false positives.
+    - name: Count manager_process.py subprocesses after lookups
+      ansible.builtin.shell: |
+        pgrep -c -f manager_process[.]py || echo 0
+      register: manager_proc_count
+      changed_when: false
+
+    - name: Assert no new manager processes are lingering after lookups
+      ansible.builtin.assert:
+        that:
+          - manager_proc_count.stdout | trim | int <= manager_proc_baseline.stdout | trim | int
+        fail_msg: >-
+          {{ manager_proc_count.stdout | trim | int - manager_proc_baseline.stdout | trim | int }}
+          new manager_process.py subprocess(es) still running after all lookup
+          tasks completed (baseline={{ manager_proc_baseline.stdout | trim }},
+          after={{ manager_proc_count.stdout | trim }}) — ephemeral manager
+          cleanup is broken.
+        success_msg: >-
+          Ephemeral manager processes cleaned up successfully
+          (baseline={{ manager_proc_baseline.stdout | trim }},
+          after={{ manager_proc_count.stdout | trim }}).
 
   always:
     # <Cleanup>

--- a/tests/unit/plugins/plugin_utils/manager/test_process_manager_cleanup.py
+++ b/tests/unit/plugins/plugin_utils/manager/test_process_manager_cleanup.py
@@ -1,0 +1,152 @@
+# (c) 2026 Red Hat Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for ProcessManager.terminate_manager_process() and the _process
+attribute stored by spawn_ephemeral_client().
+
+Run with pytest from collection root:
+  pytest tests/unit/plugins/plugin_utils/manager/test_process_manager_cleanup.py -v
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import subprocess
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ansible_collections.ansible.platform.plugins.plugin_utils.manager.process_manager import ProcessManager
+
+# ---------------------------------------------------------------------------
+# terminate_manager_process
+# ---------------------------------------------------------------------------
+
+
+class TestTerminateManagerProcess(unittest.TestCase):
+    def test_noop_when_process_is_none(self):
+        """None process must not raise."""
+        ProcessManager.terminate_manager_process(None)
+
+    def test_noop_when_process_already_exited(self):
+        """Process that has already exited must not send signals."""
+        proc = MagicMock()
+        proc.poll.return_value = 0  # already dead
+
+        ProcessManager.terminate_manager_process(proc)
+
+        proc.terminate.assert_not_called()
+        proc.kill.assert_not_called()
+
+    def test_graceful_sigterm_when_process_exits_in_time(self):
+        """Running process that exits within timeout: only SIGTERM, no SIGKILL."""
+        proc = MagicMock()
+        proc.poll.return_value = None  # still running
+        proc.wait.return_value = 0  # exits cleanly within timeout
+
+        ProcessManager.terminate_manager_process(proc, timeout=5)
+
+        proc.terminate.assert_called_once()
+        proc.wait.assert_called_once_with(timeout=5)
+        proc.kill.assert_not_called()
+
+    def test_escalates_to_sigkill_on_timeout(self):
+        """When SIGTERM doesn't work within timeout, SIGKILL is sent."""
+        proc = MagicMock()
+        proc.poll.return_value = None
+        proc.wait.side_effect = [subprocess.TimeoutExpired([], 5), None]
+
+        ProcessManager.terminate_manager_process(proc, timeout=5)
+
+        proc.terminate.assert_called_once()
+        proc.kill.assert_called_once()
+        assert proc.wait.call_count == 2
+
+    def test_sigkill_fallback_on_unexpected_exception(self):
+        """If terminate() raises an unexpected exception, kill() is still attempted."""
+        proc = MagicMock()
+        proc.poll.return_value = None
+        proc.terminate.side_effect = OSError("unexpected")
+
+        # Should not propagate — kill fallback runs instead
+        ProcessManager.terminate_manager_process(proc, timeout=5)
+
+        proc.kill.assert_called_once()
+
+    def test_default_timeout_is_five_seconds(self):
+        """Default timeout passed to wait() is 5."""
+        proc = MagicMock()
+        proc.poll.return_value = None
+        proc.wait.return_value = 0
+
+        ProcessManager.terminate_manager_process(proc)
+
+        proc.wait.assert_called_once_with(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# spawn_ephemeral_client — _process attribute
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnEphemeralClientStoresProcess(unittest.TestCase):
+    def _make_gateway_config(self):
+        from ansible_collections.ansible.platform.plugins.plugin_utils.platform.config import GatewayConfig
+
+        return GatewayConfig(base_url="https://gateway.test.invalid", username="admin", password="secret")
+
+    def test_process_attribute_set_on_returned_client(self):
+        """spawn_ephemeral_client must store the Popen handle as client._process."""
+        fake_process = MagicMock()
+        fake_process.pid = 99999
+        fake_client = MagicMock()
+        fake_client._ephemeral = True
+
+        with (
+            patch(
+                "ansible_collections.ansible.platform.plugins.plugin_utils.manager.process_manager._af_unix_available",
+                return_value=True,
+            ),
+            patch(
+                "ansible_collections.ansible.platform.plugins.plugin_utils.manager.process_manager.ProcessManager.generate_connection_info"
+            ) as mock_conn_info,
+            patch("ansible_collections.ansible.platform.plugins.plugin_utils.manager.process_manager.ProcessManager.cleanup_old_socket"),
+            patch(
+                "ansible_collections.ansible.platform.plugins.plugin_utils.manager.process_manager.ProcessManager.spawn_manager_process",
+                return_value=fake_process,
+            ),
+            patch("ansible_collections.ansible.platform.plugins.plugin_utils.manager.process_manager.ProcessManager.wait_for_process_startup"),
+            patch(
+                "ansible_collections.ansible.platform.plugins.plugin_utils.manager.rpc_client.ManagerRPCClient",
+                return_value=fake_client,
+            ),
+        ):
+            mock_conn_info.return_value = MagicMock(socket_path="/tmp/ap/test.sock", authkey=b"x" * 32, authkey_b64="abc")
+
+            from ansible_collections.ansible.platform.plugins.plugin_utils.manager.process_manager import spawn_ephemeral_client
+
+            client, facts = spawn_ephemeral_client({}, self._make_gateway_config())
+
+        assert facts is None
+        assert hasattr(client, "_process"), "client._process must be set by spawn_ephemeral_client"
+        assert client._process is fake_process
+
+    def test_no_process_attribute_on_direct_http_fallback(self):
+        """When AF_UNIX is unavailable, DirectHTTPClient is returned with no _process."""
+        with (
+            patch(
+                "ansible_collections.ansible.platform.plugins.plugin_utils.manager.process_manager._af_unix_available",
+                return_value=False,
+            ),
+            patch("ansible_collections.ansible.platform.plugins.plugin_utils.platform.direct_client.DirectHTTPClient") as MockDirect,
+        ):
+            fake_direct = MagicMock(spec=[])  # no attributes pre-defined
+            MockDirect.return_value = fake_direct
+
+            from ansible_collections.ansible.platform.plugins.plugin_utils.manager.process_manager import spawn_ephemeral_client
+
+            client, facts = spawn_ephemeral_client({}, self._make_gateway_config())
+
+        assert not hasattr(client, "_process"), "DirectHTTPClient path must not set _process"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
Backport fix of changes already merged into devel - https://github.com/ansible/ansible.platform/pull/229 + Integration Fixes in https://github.com/ansible/ansible.platform/pull/231
## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change
