### PR TITLE
Fix integration tests in devel to bring consistency with stable-2.7

### DIFF
--- a/tests/integration/targets/lookup_test/tasks/main.yml
+++ b/tests/integration/targets/lookup_test/tasks/main.yml
@@ -70,6 +70,7 @@
       ansible.builtin.shell: |
         pgrep -c -f manager_process[.]py || echo 0
       register: manager_proc_baseline
+      delegate_to: localhost
       changed_when: false
 
     - name: Use lookup plugin to query created objects
@@ -145,6 +146,7 @@
       ansible.builtin.shell: |
         pgrep -c -f manager_process[.]py || echo 0
       register: manager_proc_count
+      delegate_to: localhost
       changed_when: false
 
     - name: Assert no new manager processes are lingering after lookups

--- a/tests/integration/targets/setup_gateway/tasks/main.yml
+++ b/tests/integration/targets/setup_gateway/tasks/main.yml
@@ -6,8 +6,17 @@
     url_username: "{{ gateway_username }}"
     url_password: "{{ gateway_password }}"
     validate_certs: "{{ gateway_validate_certs }}"
+  delegate_to: localhost
   register: server_ping
   until: server_ping is not failed
   retries: 30
   delay: 2
+
+- name: Configure connection mode for this test run
+  ansible.builtin.set_fact:
+    ansible_connection: >-
+      {{ 'ansible.platform.http' if connection_mode | default('local') in ['http-direct', 'http-persistent'] else 'local' }}
+    ansible_platform_use_persistent_connection: >-
+      {{ connection_mode | default('local') == 'http-persistent' }}
+  when: connection_mode is defined
 ...


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
Integration tests file, in particular [setup_gateway/tasks/main.yml](https://github.com/ansible/ansible.platform/blob/devel/tests/integration/targets/setup_gateway/tasks/main.yml) is being made consistent with stable-2.7

`delegate_to: localhost` is being added to pgrep lines as lookup plugins are meant be run on controller node, hence process count is required to be known from there

- Why is this change needed?
Even though the test said http-*, it was still running locally on devel, unlike stable-2.7. 
Files: 
[stable-2.7](https://github.com/ansible/ansible.platform/blob/stable-2.7/tests/integration/targets/setup_gateway/tasks/main.yml)
[devel](https://github.com/ansible/ansible.platform/blob/devel/tests/integration/targets/setup_gateway/tasks/main.yml)

This was noticed when gateway_api tests were successful in devel, but failed in stable-2.7
PRs that prove this:
https://github.com/ansible/ansible.platform/pull/229 (successful)
https://github.com/ansible/ansible.platform/pull/230 (failed against stable-2.7)
This ideally shouldn't be the case as we cherry-pick devel commits and apply it to stable-2.7
- How does this change address the issue?
Bring consistency among devel and stable-2.7 setup_gateway files

## Type of Change
<!-- Mandatory: Check one or more boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Test update
- [ ] Refactoring (no functional changes)
- [ ] Development environment change
- [ ] Configuration change



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration checks by running local process and gateway availability checks on the controlling host.
  * Added connection-specific configuration for gateway setup, improving reliability across supported connection modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->