### PR TITLE
[AAP-86280] | [stable-2.7] | Enforce changelog as a requirement to any incoming module change

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -109,6 +109,12 @@ jobs:
         run: ansible-doc --version
         if: failure()
 
+  changelog:
+    uses: ansible/ansible-content-actions/.github/workflows/changelog.yaml@main
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+
   ansible-lint:
     name: Run ansible-lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
<!-- Mandatory: Provide a clear, concise description of the changes and their purpose -->
- What is being changed?
I've seen multiple PRs to devel where changelog fragment does not exist and hence during release, you are forced to go through changes and see what PR does what to add release summary. This enforces changelog to stable-2.7.
- Why is this change needed?
Without changelog, it gets messy to track things and easily identify which release had what change and by whom
- How does this change address the issue?
Uses existing workflow already implemented in networking collections
