### PR TITLE
Add inventory aap_ca_bundle for Gateway TLS verification (ANSTRAT-2452)

### DIFF
--- a/changelogs/fragments/aap_ca_bundle_inventory_var.yml
+++ b/changelogs/fragments/aap_ca_bundle_inventory_var.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - auth - Add inventory variable ``aap_ca_bundle`` (aliases ``gateway_ca_bundle``,
+    ``ansible_platform_ca_bundle``) to supply a control-node CA bundle path for Gateway
+    TLS verification without per-task ``environment:`` blocks. The path is forwarded to
+    manager subprocesses as ``REQUESTS_CA_BUNDLE`` when ``aap_validate_certs`` is enabled.

--- a/changelogs/fragments/aap_ca_bundle_inventory_var.yml
+++ b/changelogs/fragments/aap_ca_bundle_inventory_var.yml
@@ -4,3 +4,4 @@ minor_changes:
     ``ansible_platform_ca_bundle``) to supply a control-node CA bundle path for Gateway
     TLS verification without per-task ``environment:`` blocks. The path is forwarded to
     manager subprocesses as ``REQUESTS_CA_BUNDLE`` when ``aap_validate_certs`` is enabled.
+...

--- a/plugins/action/base_action.py
+++ b/plugins/action/base_action.py
@@ -387,8 +387,8 @@ class BaseResourceActionPlugin(ActionBase):
         gateway_config = extract_gateway_config(task_args=self._task.args, host_vars=task_vars, required=True)
 
         # Collect task-level environment vars (e.g. SSL_CERT_FILE, REQUESTS_CA_BUNDLE, proxy
-        # settings) BEFORE dispatching so they can be forwarded to the manager subprocess
-        # regardless of which connection mode is in use (local, http-direct, http-persistent).
+        # settings) and inventory aap_ca_bundle BEFORE dispatching so they reach the manager
+        # subprocess regardless of which connection mode is in use (local, http-direct, http-persistent).
         task_env: dict = {}
         for _env_block in self._task.environment or []:
             if isinstance(_env_block, dict):

--- a/plugins/action/base_action.py
+++ b/plugins/action/base_action.py
@@ -285,6 +285,9 @@ class BaseResourceActionPlugin(ActionBase):
             "aap_token",
             "aap_validate_certs",
             "aap_request_timeout",
+            "aap_ca_bundle",
+            "gateway_ca_bundle",
+            "ansible_platform_ca_bundle",
         }
     )
     _ANSIBLE_DIRECTIVES = frozenset({"state", "new_name"})

--- a/plugins/doc_fragments/auth.py
+++ b/plugins/doc_fragments/auth.py
@@ -55,8 +55,10 @@ options:
     - When set with C(aap_validate_certs=true), the collection forwards this path to the
       manager subprocess as E(REQUESTS_CA_BUNDLE) so private or enterprise CA chains work
       without installing trust material in the system CA store.
-    - Task parameters override inventory variables. Task or play C(environment) values for
-      E(REQUESTS_CA_BUNDLE) override this inventory variable.
+    - This parameter is authentication-only and is stripped before the resource API model
+      is instantiated (see C(BaseResourceActionPlugin._AUTH_PARAMS)).
+    - Precedence for E(REQUESTS_CA_BUNDLE) is control-node shell environment, then task
+      or play C(environment), then this inventory variable.
     type: path
     aliases: [ gateway_ca_bundle, ansible_platform_ca_bundle ]
   aap_request_timeout:

--- a/plugins/doc_fragments/auth.py
+++ b/plugins/doc_fragments/auth.py
@@ -48,6 +48,17 @@ options:
     - If value not set, will try environment variable C(GATEWAY_VERIFY_SSL), or E(AAP_VALIDATE_CERTS).
     type: bool
     aliases: [ validate_certs, gateway_validate_certs ]
+  aap_ca_bundle:
+    description:
+    - Path on the Ansible control node to a PEM file containing trusted CA certificate(s)
+      used to verify the automation platform gateway TLS certificate.
+    - When set with C(aap_validate_certs=true), the collection forwards this path to the
+      manager subprocess as E(REQUESTS_CA_BUNDLE) so private or enterprise CA chains work
+      without installing trust material in the system CA store.
+    - Task parameters override inventory variables. Task or play C(environment) values for
+      E(REQUESTS_CA_BUNDLE) override this inventory variable.
+    type: path
+    aliases: [ gateway_ca_bundle, ansible_platform_ca_bundle ]
   aap_request_timeout:
     description:
     - Specify the timeout Ansible should use in requests to the automation platform gateway.

--- a/plugins/plugin_utils/api/v1/token.py
+++ b/plugins/plugin_utils/api/v1/token.py
@@ -52,7 +52,7 @@ def _resolve_application_id(manager, application, organization=None):
             query_params["organization"] = org_id
 
     url = manager._build_url("applications", query_params=query_params)
-    response = manager.session.get(url, timeout=manager.request_timeout, verify=manager.verify_ssl)
+    response = manager.session.get(url, timeout=manager.request_timeout, verify=manager.requests_verify)
     response.raise_for_status()
     results = response.json().get("results", [])
 

--- a/plugins/plugin_utils/manager/platform_manager.py
+++ b/plugins/plugin_utils/manager/platform_manager.py
@@ -164,7 +164,7 @@ class PlatformService(BaseAPIClient):
             if "timeout" not in request_kwargs:
                 request_kwargs["timeout"] = self.request_timeout
             if "verify" not in request_kwargs:
-                request_kwargs["verify"] = self.verify_ssl
+                request_kwargs["verify"] = self.requests_verify
 
             session_method = getattr(self.session, method.lower())
 
@@ -214,7 +214,7 @@ class PlatformService(BaseAPIClient):
                 header = {"Authorization": f"Bearer {oauth_token}"}
                 self.session.headers.update(header)
                 try:
-                    response = self.session.get(url, timeout=self.request_timeout, verify=self.verify_ssl)
+                    response = self.session.get(url, timeout=self.request_timeout, verify=self.requests_verify)
                     response.raise_for_status()
                     self._last_auth_error = None
                 except requests.RequestException as e:
@@ -225,7 +225,7 @@ class PlatformService(BaseAPIClient):
                 header = {"Authorization": f"Basic {basic_str.decode('ascii')}"}
                 self.session.headers.update(header)
                 try:
-                    response = self.session.get(url, timeout=self.request_timeout, verify=self.verify_ssl)
+                    response = self.session.get(url, timeout=self.request_timeout, verify=self.requests_verify)
                     response.raise_for_status()
                     self._last_auth_error = None
                 except requests.RequestException as e:
@@ -269,7 +269,7 @@ class PlatformService(BaseAPIClient):
             try:
                 refresh_url = f"{self.base_url}/api/gateway/v1/auth/token/refresh/"
                 response = self.session.post(
-                    refresh_url, json={"refresh_token": token_info.refresh_token}, timeout=self.request_timeout, verify=self.verify_ssl
+                    refresh_url, json={"refresh_token": token_info.refresh_token}, timeout=self.request_timeout, verify=self.requests_verify
                 )
 
                 if response.status_code == 200:
@@ -386,7 +386,7 @@ class PlatformService(BaseAPIClient):
             ping_url = f"{self.base_url.rstrip('/')}/api/gateway/v1/ping/"
             logger.debug("PlatformService: version detection tier-1 %s", ping_url)
 
-            response = self.session.get(ping_url, timeout=self.request_timeout, verify=self.verify_ssl)
+            response = self.session.get(ping_url, timeout=self.request_timeout, verify=self.requests_verify)
             response.raise_for_status()
 
             # Only trust the X-API-Version header from the ping endpoint.
@@ -415,7 +415,7 @@ class PlatformService(BaseAPIClient):
             root_url = f"{self.base_url.rstrip('/')}/api/gateway/"
             logger.debug("PlatformService: version detection tier-2 %s", root_url)
 
-            response = self.session.get(root_url, timeout=self.request_timeout, verify=self.verify_ssl)
+            response = self.session.get(root_url, timeout=self.request_timeout, verify=self.requests_verify)
             response.raise_for_status()
 
             v = _hdr_version(response)
@@ -798,7 +798,7 @@ class PlatformService(BaseAPIClient):
 
         url = self._build_url(path)
         logger.debug("Calling DELETE %s", url)
-        response = self.session.delete(url, timeout=self.request_timeout, verify=self.verify_ssl)
+        response = self.session.delete(url, timeout=self.request_timeout, verify=self.requests_verify)
         response.raise_for_status()
         return {"changed": True, "id": resource_id}
 
@@ -828,7 +828,7 @@ class PlatformService(BaseAPIClient):
             if not get_op:
                 raise ValueError("No GET operation defined for singleton resource")
             url = self._build_url(get_op.path)
-            response = self.session.get(url, timeout=self.request_timeout, verify=self.verify_ssl)
+            response = self.session.get(url, timeout=self.request_timeout, verify=self.requests_verify)
             response.raise_for_status()
             api_result = response.json()
             ansible_instance = mixin_class.from_api(api_result, context)
@@ -863,7 +863,7 @@ class PlatformService(BaseAPIClient):
             if not get_op:
                 raise ValueError("No GET operation defined for this resource")
             url = self._build_url(get_op.path.replace("{id}", str(resolved_id)))
-            response = self.session.get(url, timeout=self.request_timeout, verify=self.verify_ssl)
+            response = self.session.get(url, timeout=self.request_timeout, verify=self.requests_verify)
             response.raise_for_status()
             api_result = response.json()
 
@@ -896,7 +896,7 @@ class PlatformService(BaseAPIClient):
                 query_params.update(composite_params)
             url = self._build_url(list_op.path, query_params=query_params)
             logger.debug("Calling GET %s to find %s=%s (query_params=%s)", url, lookup_field, unique_value, query_params)
-            response = self.session.get(url, timeout=self.request_timeout, verify=self.verify_ssl)
+            response = self.session.get(url, timeout=self.request_timeout, verify=self.requests_verify)
             response.raise_for_status()
             list_result = response.json()
 
@@ -913,7 +913,7 @@ class PlatformService(BaseAPIClient):
             if getattr(mixin_class, "full_resource_lookup", False) and api_result.get("id") and get_op:
                 full_url = self._build_url(get_op.path.replace("{id}", str(api_result["id"])))
                 logger.debug("full_resource_lookup: GET %s for complete resource data", full_url)
-                full_response = self.session.get(full_url, timeout=self.request_timeout, verify=self.verify_ssl)
+                full_response = self.session.get(full_url, timeout=self.request_timeout, verify=self.requests_verify)
                 if full_response.ok:
                     api_result = full_response.json()
 
@@ -990,7 +990,7 @@ class PlatformService(BaseAPIClient):
                 with self._lock:
                     self._http_request_count += 1
 
-                response = self.session.request(endpoint_op.method, url, json=request_data, timeout=self.request_timeout, verify=self.verify_ssl)
+                response = self.session.request(endpoint_op.method, url, json=request_data, timeout=self.request_timeout, verify=self.requests_verify)
                 response.raise_for_status()
 
             except Exception as e:
@@ -1067,7 +1067,7 @@ class PlatformService(BaseAPIClient):
                 continue
 
             url = self._build_url("organizations", query_params={"name": name})
-            response = self.session.get(url, timeout=self.request_timeout, verify=self.verify_ssl)
+            response = self.session.get(url, timeout=self.request_timeout, verify=self.requests_verify)
             response.raise_for_status()
             results = response.json().get("results", [])
 
@@ -1098,7 +1098,7 @@ class PlatformService(BaseAPIClient):
                 continue
 
             url = self._build_url(f"organizations/{org_id}/")
-            response = self.session.get(url, timeout=self.request_timeout, verify=self.verify_ssl)
+            response = self.session.get(url, timeout=self.request_timeout, verify=self.requests_verify)
             response.raise_for_status()
             org = response.json()
 
@@ -1132,7 +1132,7 @@ class PlatformService(BaseAPIClient):
         if cache_key in self.cache:
             return self.cache[cache_key]
         url = self._build_url(endpoint, query_params={lookup_field: lookup_value})
-        response = self.session.get(url, timeout=self.request_timeout, verify=self.verify_ssl)
+        response = self.session.get(url, timeout=self.request_timeout, verify=self.requests_verify)
         response.raise_for_status()
         results = response.json().get("results", [])
         if not results:

--- a/plugins/plugin_utils/manager/process_manager.py
+++ b/plugins/plugin_utils/manager/process_manager.py
@@ -310,15 +310,20 @@ class ProcessManager:
         4. Deprecated ``SSL_CERT_FILE`` → ``REQUESTS_CA_BUNDLE`` shim
         """
         env = os.environ.copy()
+        shell_had_requests_ca = "REQUESTS_CA_BUNDLE" in os.environ
+
         if task_env:
-            env.update({k: str(v) for k, v in task_env.items() if v is not None})
+            filtered_task_env = {k: str(v) for k, v in task_env.items() if v is not None}
+            if shell_had_requests_ca and "REQUESTS_CA_BUNDLE" in filtered_task_env:
+                filtered_task_env = {k: v for k, v in filtered_task_env.items() if k != "REQUESTS_CA_BUNDLE"}
+            env.update(filtered_task_env)
             logger.debug("Applied %d task-level environment variable(s) to manager subprocess", len(task_env))
 
-        if gateway_config.verify_ssl and gateway_config.ca_bundle and not env.get("REQUESTS_CA_BUNDLE"):
+        if gateway_config.verify_ssl and gateway_config.ca_bundle and "REQUESTS_CA_BUNDLE" not in env:
             env["REQUESTS_CA_BUNDLE"] = gateway_config.ca_bundle
             logger.debug("Applied inventory CA bundle to manager subprocess REQUESTS_CA_BUNDLE")
 
-        if env.get("SSL_CERT_FILE") and not env.get("REQUESTS_CA_BUNDLE"):
+        if env.get("SSL_CERT_FILE") and "REQUESTS_CA_BUNDLE" not in env:
             env["REQUESTS_CA_BUNDLE"] = env["SSL_CERT_FILE"]
             logger.warning(
                 "Deprecated: SSL_CERT_FILE is being mapped to REQUESTS_CA_BUNDLE for backward compatibility. "

--- a/plugins/plugin_utils/manager/process_manager.py
+++ b/plugins/plugin_utils/manager/process_manager.py
@@ -253,20 +253,8 @@ class ProcessManager:
         sys_path_json = json.dumps(sys_path)
         sys_path_b64 = base64.b64encode(sys_path_json.encode("utf-8")).decode("utf-8")
 
-        # Build subprocess environment: shell env + task-level overrides.
-        env = os.environ.copy()
-        if task_env:
-            env.update({k: str(v) for k, v in task_env.items() if v is not None})
-            logger.debug("Applied %d task-level environment variable(s) to manager subprocess", len(task_env))
-
-        if env.get("SSL_CERT_FILE") and not env.get("REQUESTS_CA_BUNDLE"):
-            env["REQUESTS_CA_BUNDLE"] = env["SSL_CERT_FILE"]
-            logger.warning(
-                "Deprecated: SSL_CERT_FILE is being mapped to REQUESTS_CA_BUNDLE for backward compatibility. "
-                "The manager subprocess uses the requests library which reads REQUESTS_CA_BUNDLE, not SSL_CERT_FILE. "
-                "Please set REQUESTS_CA_BUNDLE directly in your environment block. "
-                "SSL_CERT_FILE support will be removed in a future release."
-            )
+        # Build subprocess environment: shell env + task-level overrides + inventory CA bundle.
+        env = ProcessManager.merge_manager_environment(gateway_config, task_env=task_env)
 
         env["ANSIBLE_PLATFORM_SYS_PATH"] = sys_path_b64
         env["ANSIBLE_PLATFORM_AUTHKEY"] = authkey_b64
@@ -310,6 +298,36 @@ class ProcessManager:
 
             logger.error(traceback.format_exc())
             raise RuntimeError(f"Failed to start manager process: {e}") from e
+
+    @staticmethod
+    def merge_manager_environment(gateway_config: "GatewayConfig", task_env: Optional[dict] = None) -> dict:
+        """Build the manager subprocess environment for TLS and proxy settings.
+
+        Precedence for ``REQUESTS_CA_BUNDLE``:
+        1. Existing control-node shell environment
+        2. Task/play ``environment:`` block (``task_env``)
+        3. Inventory ``aap_ca_bundle`` / aliases when ``verify_ssl`` is enabled
+        4. Deprecated ``SSL_CERT_FILE`` → ``REQUESTS_CA_BUNDLE`` shim
+        """
+        env = os.environ.copy()
+        if task_env:
+            env.update({k: str(v) for k, v in task_env.items() if v is not None})
+            logger.debug("Applied %d task-level environment variable(s) to manager subprocess", len(task_env))
+
+        if gateway_config.verify_ssl and gateway_config.ca_bundle and not env.get("REQUESTS_CA_BUNDLE"):
+            env["REQUESTS_CA_BUNDLE"] = gateway_config.ca_bundle
+            logger.debug("Applied inventory CA bundle to manager subprocess REQUESTS_CA_BUNDLE")
+
+        if env.get("SSL_CERT_FILE") and not env.get("REQUESTS_CA_BUNDLE"):
+            env["REQUESTS_CA_BUNDLE"] = env["SSL_CERT_FILE"]
+            logger.warning(
+                "Deprecated: SSL_CERT_FILE is being mapped to REQUESTS_CA_BUNDLE for backward compatibility. "
+                "The manager subprocess uses the requests library which reads REQUESTS_CA_BUNDLE, not SSL_CERT_FILE. "
+                "Please set REQUESTS_CA_BUNDLE directly in your environment block. "
+                "SSL_CERT_FILE support will be removed in a future release."
+            )
+
+        return env
 
     @staticmethod
     def wait_for_process_startup(socket_path: str, socket_dir: Path, identifier: str, process: subprocess.Popen, max_wait: int = 50) -> None:

--- a/plugins/plugin_utils/platform/base_client.py
+++ b/plugins/plugin_utils/platform/base_client.py
@@ -41,6 +41,7 @@ class BaseAPIClient(ABC):
         self.config = config
         self.base_url = config.base_url.rstrip("/")
         self.verify_ssl = config.verify_ssl
+        self.ca_bundle = config.ca_bundle
         self.request_timeout = config.request_timeout
 
         # Shared: Version detection infrastructure
@@ -54,6 +55,11 @@ class BaseAPIClient(ABC):
         self.cache: Dict[str, Any] = {}
 
         logger.info("BaseAPIClient initialized: base_url=%s, mode=%s", self.base_url, config.connection_mode)
+
+    @property
+    def requests_verify(self):
+        """TLS verify parameter for HTTP clients (bool or CA bundle path)."""
+        return self.config.requests_verify
 
     @abstractmethod
     def _detect_api_version(self) -> str:

--- a/plugins/plugin_utils/platform/base_client.py
+++ b/plugins/plugin_utils/platform/base_client.py
@@ -69,6 +69,14 @@ class BaseAPIClient(ABC):
             return ca_bundle
         return True
 
+    def _ansible_tls_kwargs(self, verify=None):
+        """Map TLS verify setting to Ansible Request validate_certs/ca_path kwargs."""
+        if verify is None:
+            verify = self.requests_verify
+        if isinstance(verify, str):
+            return {"validate_certs": True, "ca_path": verify}
+        return {"validate_certs": bool(verify), "ca_path": None}
+
     @abstractmethod
     def _detect_api_version(self) -> str:
         """

--- a/plugins/plugin_utils/platform/base_client.py
+++ b/plugins/plugin_utils/platform/base_client.py
@@ -59,7 +59,15 @@ class BaseAPIClient(ABC):
     @property
     def requests_verify(self):
         """TLS verify parameter for HTTP clients (bool or CA bundle path)."""
-        return self.config.requests_verify
+        config = getattr(self, "config", None)
+        if config is not None:
+            return config.requests_verify
+        if not getattr(self, "verify_ssl", True):
+            return False
+        ca_bundle = getattr(self, "ca_bundle", None)
+        if ca_bundle:
+            return ca_bundle
+        return True
 
     @abstractmethod
     def _detect_api_version(self) -> str:

--- a/plugins/plugin_utils/platform/config.py
+++ b/plugins/plugin_utils/platform/config.py
@@ -6,7 +6,7 @@ This module is part of the platform SDK and is not Ansible-specific.
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +24,7 @@ class GatewayConfig:
     password: Optional[str] = None
     oauth_token: Optional[str] = None
     verify_ssl: bool = True
+    ca_bundle: Optional[str] = None
     request_timeout: float = 10.0
     connection_mode: str = "standard"  # "standard" or "experimental"
     idle_timeout: float = 3600.0
@@ -39,12 +40,22 @@ class GatewayConfig:
                 self.base_url,
             )
         logger.info(
-            "GatewayConfig initialized: base_url=%s, verify_ssl=%s, timeout=%s, idle_timeout=%s",
+            "GatewayConfig initialized: base_url=%s, verify_ssl=%s, ca_bundle=%s, timeout=%s, idle_timeout=%s",
             self.base_url,
             self.verify_ssl,
+            self.ca_bundle,
             self.request_timeout,
             self.idle_timeout,
         )
+
+    @property
+    def requests_verify(self) -> Union[bool, str]:
+        """Value passed to requests ``verify=`` for TLS validation."""
+        if not self.verify_ssl:
+            return False
+        if self.ca_bundle:
+            return self.ca_bundle
+        return True
 
     @staticmethod
     def _normalize_url(url: str) -> str:
@@ -81,6 +92,25 @@ def _extract_persistent_manager_idle_timeout(
         return task_args["persistent_manager_idle_timeout"]
     if "persistent_manager_idle_timeout" in host_vars:
         return host_vars["persistent_manager_idle_timeout"]
+    return None
+
+
+def _resolve_ca_bundle(
+    task_args: Dict[str, Any],
+    host_vars: Dict[str, Any],
+) -> Optional[str]:
+    """Return a CA bundle path from task or inventory scope.
+
+    Aliases: aap_ca_bundle (primary), gateway_ca_bundle, ansible_platform_ca_bundle.
+    Task arguments override host/inventory variables.
+    """
+    _ca_bundle_keys = ("aap_ca_bundle", "gateway_ca_bundle", "ansible_platform_ca_bundle")
+    for scope in (task_args, host_vars):
+        for key in _ca_bundle_keys:
+            if key in scope:
+                value = scope[key]
+                if value is not None and value != "":
+                    return str(value)
     return None
 
 
@@ -178,6 +208,7 @@ def extract_gateway_config(
     # Local persistent manager idle shutdown (not a gateway session timeout).
     # Default: 3600 s. Set to 0 to disable. See _extract_persistent_manager_idle_timeout.
     pm_idle_timeout = _extract_persistent_manager_idle_timeout(task_args, host_vars)
+    gateway_ca_bundle = _resolve_ca_bundle(task_args, host_vars)
     # Connection mode: "standard" (default) or "experimental" (persistent manager)
     connection_mode = task_args.get("platform_connection_mode") or host_vars.get("platform_connection_mode") or "standard"
 
@@ -193,10 +224,11 @@ def extract_gateway_config(
     else:
         auth_method = "none"
     logger.info(
-        "Gateway config extracted: url=%s, auth_method=%s, verify_ssl=%s, timeout=%s",
+        "Gateway config extracted: url=%s, auth_method=%s, verify_ssl=%s, ca_bundle=%s, timeout=%s",
         gateway_url,
         auth_method,
         gateway_validate_certs,
+        gateway_ca_bundle,
         gateway_request_timeout,
     )
 
@@ -206,6 +238,7 @@ def extract_gateway_config(
         password=gateway_password,
         oauth_token=gateway_token,
         verify_ssl=gateway_validate_certs,
+        ca_bundle=gateway_ca_bundle,
         request_timeout=gateway_request_timeout,
         connection_mode=connection_mode,
         idle_timeout=(float(pm_idle_timeout) if pm_idle_timeout is not None else 3600.0),

--- a/plugins/plugin_utils/platform/direct_client.py
+++ b/plugins/plugin_utils/platform/direct_client.py
@@ -73,7 +73,7 @@ class DirectHTTPClient(BaseAPIClient):
 
         # Initialize session using Ansible's Request (like current collection)
         # This is more compatible with Ansible worker processes
-        self.session = Request(cookies=CookieJar(), validate_certs=self.verify_ssl, timeout=self.request_timeout)
+        self.session = Request(cookies=CookieJar(), validate_certs=self.requests_verify, timeout=self.request_timeout)
         self.session.headers.update({"User-Agent": "Ansible Platform Collection", "Accept": "application/json", "Content-Type": "application/json"})
 
         # Track authentication state
@@ -132,7 +132,7 @@ class DirectHTTPClient(BaseAPIClient):
         try:
             ping_url = f"{self.base_url.rstrip('/')}/api/gateway/v1/ping/"
             logger.debug("DirectHTTPClient: version detection tier-1 %s", ping_url)
-            response = self.session.open("GET", ping_url, validate_certs=self.verify_ssl, timeout=self.request_timeout)
+            response = self.session.open("GET", ping_url, validate_certs=self.requests_verify, timeout=self.request_timeout)
 
             # Only trust the X-API-Version header from the ping endpoint.
             # The JSON body "version" field is the *product* version
@@ -157,7 +157,7 @@ class DirectHTTPClient(BaseAPIClient):
         try:
             root_url = f"{self.base_url.rstrip('/')}/api/gateway/"
             logger.debug("DirectHTTPClient: version detection tier-2 %s", root_url)
-            response = self.session.open("GET", root_url, validate_certs=self.verify_ssl, timeout=self.request_timeout)
+            response = self.session.open("GET", root_url, validate_certs=self.requests_verify, timeout=self.request_timeout)
 
             v = _hdr_version(response)
             if v:
@@ -246,7 +246,7 @@ class DirectHTTPClient(BaseAPIClient):
         # Set default timeout and verify_ssl if not provided
         request_kwargs = kwargs.copy()
         timeout = request_kwargs.pop("timeout", self.request_timeout)
-        verify = request_kwargs.pop("verify", self.verify_ssl)
+        verify = request_kwargs.pop("verify", self.requests_verify)
 
         # Prepare data for JSON requests
         data = None

--- a/plugins/plugin_utils/platform/direct_client.py
+++ b/plugins/plugin_utils/platform/direct_client.py
@@ -73,7 +73,13 @@ class DirectHTTPClient(BaseAPIClient):
 
         # Initialize session using Ansible's Request (like current collection)
         # This is more compatible with Ansible worker processes
-        self.session = Request(cookies=CookieJar(), validate_certs=self.requests_verify, timeout=self.request_timeout)
+        tls_kwargs = self._ansible_tls_kwargs()
+        self.session = Request(
+            cookies=CookieJar(),
+            validate_certs=tls_kwargs["validate_certs"],
+            ca_path=tls_kwargs["ca_path"],
+            timeout=self.request_timeout,
+        )
         self.session.headers.update({"User-Agent": "Ansible Platform Collection", "Accept": "application/json", "Content-Type": "application/json"})
 
         # Track authentication state
@@ -132,7 +138,12 @@ class DirectHTTPClient(BaseAPIClient):
         try:
             ping_url = f"{self.base_url.rstrip('/')}/api/gateway/v1/ping/"
             logger.debug("DirectHTTPClient: version detection tier-1 %s", ping_url)
-            response = self.session.open("GET", ping_url, validate_certs=self.requests_verify, timeout=self.request_timeout)
+            response = self.session.open(
+                "GET",
+                ping_url,
+                timeout=self.request_timeout,
+                **self._ansible_tls_kwargs(),
+            )
 
             # Only trust the X-API-Version header from the ping endpoint.
             # The JSON body "version" field is the *product* version
@@ -157,7 +168,12 @@ class DirectHTTPClient(BaseAPIClient):
         try:
             root_url = f"{self.base_url.rstrip('/')}/api/gateway/"
             logger.debug("DirectHTTPClient: version detection tier-2 %s", root_url)
-            response = self.session.open("GET", root_url, validate_certs=self.requests_verify, timeout=self.request_timeout)
+            response = self.session.open(
+                "GET",
+                root_url,
+                timeout=self.request_timeout,
+                **self._ansible_tls_kwargs(),
+            )
 
             v = _hdr_version(response)
             if v:
@@ -247,6 +263,7 @@ class DirectHTTPClient(BaseAPIClient):
         request_kwargs = kwargs.copy()
         timeout = request_kwargs.pop("timeout", self.request_timeout)
         verify = request_kwargs.pop("verify", self.requests_verify)
+        tls_kwargs = self._ansible_tls_kwargs(verify)
 
         # Prepare data for JSON requests
         data = None
@@ -288,10 +305,10 @@ class DirectHTTPClient(BaseAPIClient):
                 response = self.session.open(
                     method.upper(),
                     url_str,
-                    validate_certs=verify,
                     timeout=timeout,
                     follow_redirects=True,
                     data=data,
+                    **tls_kwargs,
                 )
                 status = getattr(response, "status", getattr(response, "code", "unknown"))
                 logger.info("DirectHTTPClient: Response received: status=%s", status)
@@ -322,10 +339,10 @@ class DirectHTTPClient(BaseAPIClient):
                         response = self.session.open(
                             method.upper(),
                             parsed_url.geturl() if hasattr(parsed_url, "geturl") else str(url),
-                            validate_certs=verify,
                             timeout=timeout,
                             follow_redirects=True,
                             data=data,
+                            **tls_kwargs,
                         )
                         # Success - return the response
                         return response

--- a/tests/integration/targets/ssl_env_forwarding_test/tasks/main.yml
+++ b/tests/integration/targets/ssl_env_forwarding_test/tasks/main.yml
@@ -212,6 +212,12 @@
 
 # ── Test 4: inventory aap_ca_bundle=/dev/null forces SSL failure ───────────────
 # Proves inventory-native CA bundle forwarding without per-task environment:.
+- name: Capture pre-test inventory CA bundle fact
+  ansible.builtin.set_fact:
+    _ssl_test_orig_aap_ca_bundle_defined: "{{ aap_ca_bundle is defined }}"
+    _ssl_test_orig_aap_ca_bundle: "{{ aap_ca_bundle | default('') }}"
+  when: not _skip_forwarding_tests | bool
+
 - name: "TEST 4: aap_ca_bundle=/dev/null must produce SSL error"
   when: not _skip_forwarding_tests | bool
   block:
@@ -245,9 +251,16 @@
         success_msg: >-
           TEST 4 PASSED: inventory aap_ca_bundle=/dev/null caused SSL error as expected.
 
-    - name: Clear inventory CA bundle fact
+  always:
+    - name: Restore inventory CA bundle fact after test 4
       ansible.builtin.set_fact:
-        aap_ca_bundle: null
+        aap_ca_bundle: "{{ _ssl_test_orig_aap_ca_bundle }}"
+      when: _ssl_test_orig_aap_ca_bundle_defined | bool
+
+    - name: Remove inventory CA bundle fact after test 4
+      ansible.builtin.set_fact:
+        aap_ca_bundle: "{{ omit }}"
+      when: not (_ssl_test_orig_aap_ca_bundle_defined | bool)
 
 # ── Test 5: inventory aap_ca_bundle with real CA bundle succeeds ───────────────
 - name: "TEST 5: aap_ca_bundle=<real CA bundle> allows SSL to succeed"
@@ -288,10 +301,16 @@
           TEST 5 PASSED: inventory aap_ca_bundle allowed SSL verification to succeed.
       when: _inventory_ca_bundle_stat.stat.exists
 
-    - name: Clear inventory CA bundle fact
+  always:
+    - name: Restore inventory CA bundle fact after test 5
       ansible.builtin.set_fact:
-        aap_ca_bundle: null
-      when: _inventory_ca_bundle_stat.stat.exists
+        aap_ca_bundle: "{{ _ssl_test_orig_aap_ca_bundle }}"
+      when: _ssl_test_orig_aap_ca_bundle_defined | bool
+
+    - name: Remove inventory CA bundle fact after test 5
+      ansible.builtin.set_fact:
+        aap_ca_bundle: "{{ omit }}"
+      when: not (_ssl_test_orig_aap_ca_bundle_defined | bool)
 
 - name: "TEST 5 SKIPPED"
   ansible.builtin.debug:

--- a/tests/integration/targets/ssl_env_forwarding_test/tasks/main.yml
+++ b/tests/integration/targets/ssl_env_forwarding_test/tasks/main.yml
@@ -10,6 +10,8 @@
 #   2. REQUESTS_CA_BUNDLE is read by requests inside the subprocess.
 #   3. SSL_CERT_FILE is mapped → REQUESTS_CA_BUNDLE (backward compat / deprecation shim).
 #   4. A valid CA bundle passed via REQUESTS_CA_BUNDLE allows SSL verification to succeed.
+#   5. Inventory aap_ca_bundle is forwarded to the manager subprocess without per-task environment:.
+#   6. Inventory aap_ca_bundle with a valid CA bundle allows SSL verification to succeed.
 #
 # Connection mode coverage:
 #   - local / http-direct: each task spawns a fresh ephemeral manager → env forwarding
@@ -208,6 +210,97 @@
     not _skip_forwarding_tests | bool
     and (gateway_tls_ca_bundle_path is not defined or gateway_tls_ca_bundle_path | length == 0)
 
+# ── Test 4: inventory aap_ca_bundle=/dev/null forces SSL failure ───────────────
+# Proves inventory-native CA bundle forwarding without per-task environment:.
+- name: "TEST 4: aap_ca_bundle=/dev/null must produce SSL error"
+  when: not _skip_forwarding_tests | bool
+  block:
+    - name: Set inventory CA bundle path to empty trust store
+      ansible.builtin.set_fact:
+        aap_ca_bundle: "/dev/null"
+
+    - name: Call module with inventory aap_ca_bundle only
+      ansible.platform.organization:
+        gateway_hostname: "{{ gateway_hostname }}"
+        gateway_username: "{{ gateway_username }}"
+        gateway_password: "{{ gateway_password }}"
+        gateway_validate_certs: true
+        name: "ssl-env-test-sentinel"
+        state: exists
+      register: _inventory_ca_bundle_negative
+      ignore_errors: true
+
+    - name: Assert inventory CA bundle caused SSL error
+      ansible.builtin.assert:
+        that:
+          - _inventory_ca_bundle_negative is failed
+          - >-
+            'SSL' in (_inventory_ca_bundle_negative.msg | default(''))
+            or 'certificate' in (_inventory_ca_bundle_negative.msg | default(''))
+            or 'CERTIFICATE' in (_inventory_ca_bundle_negative.msg | default(''))
+            or 'ioctl' in (_inventory_ca_bundle_negative.msg | default(''))
+        fail_msg: >-
+          Expected SSL error from inventory aap_ca_bundle=/dev/null but got:
+          {{ _inventory_ca_bundle_negative.msg | default('(no message)') }}.
+        success_msg: >-
+          TEST 4 PASSED: inventory aap_ca_bundle=/dev/null caused SSL error as expected.
+
+    - name: Clear inventory CA bundle fact
+      ansible.builtin.set_fact:
+        aap_ca_bundle: null
+
+# ── Test 5: inventory aap_ca_bundle with real CA bundle succeeds ───────────────
+- name: "TEST 5: aap_ca_bundle=<real CA bundle> allows SSL to succeed"
+  when:
+    - not _skip_forwarding_tests | bool
+    - gateway_tls_ca_bundle_path is defined
+    - gateway_tls_ca_bundle_path | length > 0
+  block:
+    - name: Verify CA bundle file exists for inventory test
+      ansible.builtin.stat:
+        path: "{{ gateway_tls_ca_bundle_path }}"
+      register: _inventory_ca_bundle_stat
+
+    - name: Set inventory CA bundle path to real trust store
+      ansible.builtin.set_fact:
+        aap_ca_bundle: "{{ gateway_tls_ca_bundle_path }}"
+      when: _inventory_ca_bundle_stat.stat.exists
+
+    - name: Call module with inventory aap_ca_bundle only
+      ansible.platform.organization:
+        gateway_hostname: "{{ gateway_hostname }}"
+        gateway_username: "{{ gateway_username }}"
+        gateway_password: "{{ gateway_password }}"
+        gateway_validate_certs: true
+        name: "ssl-env-test-sentinel"
+        state: exists
+      register: _inventory_ca_bundle_positive
+      when: _inventory_ca_bundle_stat.stat.exists
+
+    - name: Assert inventory CA bundle allowed SSL verification to succeed
+      ansible.builtin.assert:
+        that:
+          - _inventory_ca_bundle_positive is not failed
+        fail_msg: >-
+          Call failed with inventory aap_ca_bundle={{ gateway_tls_ca_bundle_path }}.
+          Error: {{ _inventory_ca_bundle_positive.msg | default('(no message)') }}.
+        success_msg: >-
+          TEST 5 PASSED: inventory aap_ca_bundle allowed SSL verification to succeed.
+      when: _inventory_ca_bundle_stat.stat.exists
+
+    - name: Clear inventory CA bundle fact
+      ansible.builtin.set_fact:
+        aap_ca_bundle: null
+      when: _inventory_ca_bundle_stat.stat.exists
+
+- name: "TEST 5 SKIPPED"
+  ansible.builtin.debug:
+    msg: >-
+      TEST 5 skipped — gateway_tls_ca_bundle_path not set in integration_config.yml.
+  when: >-
+    not _skip_forwarding_tests | bool
+    and (gateway_tls_ca_bundle_path is not defined or gateway_tls_ca_bundle_path | length == 0)
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 - name: Compute SSL env forwarding test result statuses
   ansible.builtin.set_fact:
@@ -225,6 +318,15 @@
       {{ 'PASS' if (_positive_result is defined
       and _positive_result is not failed)
       else 'SKIPPED (gateway_tls_ca_bundle_path not set)' }}
+    _ssl_t4_status: >-
+      {{ 'PASS' if (_inventory_ca_bundle_negative is defined
+      and _inventory_ca_bundle_negative is failed)
+      else 'SKIPPED (persistent mode)' if _skip_forwarding_tests | bool
+      else 'FAIL' }}
+    _ssl_t5_status: >-
+      {{ 'PASS' if (_inventory_ca_bundle_positive is defined
+      and _inventory_ca_bundle_positive is not failed)
+      else 'SKIPPED (gateway_tls_ca_bundle_path not set)' }}
 
 - name: SSL env forwarding test summary
   ansible.builtin.debug:
@@ -234,4 +336,6 @@
       - "TEST 1 (REQUESTS_CA_BUNDLE=/dev/null → SSL error) : {{ _ssl_t1_status }}"
       - "TEST 2 (SSL_CERT_FILE=/dev/null → SSL error via shim) : {{ _ssl_t2_status }}"
       - "TEST 3 (REQUESTS_CA_BUNDLE=<real CA> → success)   : {{ _ssl_t3_status }}"
+      - "TEST 4 (aap_ca_bundle=/dev/null → SSL error) : {{ _ssl_t4_status }}"
+      - "TEST 5 (aap_ca_bundle=<real CA> → success)   : {{ _ssl_t5_status }}"
 ...

--- a/tests/unit/plugins/action/test_auth_params_ca_bundle.py
+++ b/tests/unit/plugins/action/test_auth_params_ca_bundle.py
@@ -36,11 +36,7 @@ class TestAuthParamsCaBundle(unittest.TestCase):
             "ansible_platform_ca_bundle": "/tmp/platform-ca.pem",
             "gateway_hostname": "https://gateway.example",
         }
-        resource_data = {
-            k: v
-            for k, v in validated_params.items()
-            if v is not None and k not in BaseResourceActionPlugin._AUTH_PARAMS
-        }
+        resource_data = {k: v for k, v in validated_params.items() if v is not None and k not in BaseResourceActionPlugin._AUTH_PARAMS}
 
         self.assertEqual(resource_data, {"name": "ssl-env-test-org"})
         for key in self._CA_BUNDLE_KEYS:

--- a/tests/unit/plugins/action/test_auth_params_ca_bundle.py
+++ b/tests/unit/plugins/action/test_auth_params_ca_bundle.py
@@ -1,0 +1,51 @@
+# (c) 2026 Red Hat Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Tests that CA bundle auth params are stripped before model instantiation."""
+
+from __future__ import absolute_import, division, print_function
+
+import sys
+import unittest
+from pathlib import Path
+
+_COLLECTIONS_PARENT = str(Path(__file__).resolve().parent.parent.parent.parent.parent.parent)
+if _COLLECTIONS_PARENT not in sys.path:
+    sys.path.insert(0, _COLLECTIONS_PARENT)
+
+from ansible_collections.ansible.platform.plugins.action.base_action import BaseResourceActionPlugin  # noqa: E402
+
+
+class TestAuthParamsCaBundle(unittest.TestCase):
+    _CA_BUNDLE_KEYS = frozenset(
+        {
+            "aap_ca_bundle",
+            "gateway_ca_bundle",
+            "ansible_platform_ca_bundle",
+        }
+    )
+
+    def test_ca_bundle_keys_are_auth_params(self):
+        self.assertTrue(self._CA_BUNDLE_KEYS.issubset(BaseResourceActionPlugin._AUTH_PARAMS))
+
+    def test_ca_bundle_keys_stripped_from_resource_data(self):
+        validated_params = {
+            "name": "ssl-env-test-org",
+            "aap_ca_bundle": "/tmp/aap-ca.pem",
+            "gateway_ca_bundle": "/tmp/gateway-ca.pem",
+            "ansible_platform_ca_bundle": "/tmp/platform-ca.pem",
+            "gateway_hostname": "https://gateway.example",
+        }
+        resource_data = {
+            k: v
+            for k, v in validated_params.items()
+            if v is not None and k not in BaseResourceActionPlugin._AUTH_PARAMS
+        }
+
+        self.assertEqual(resource_data, {"name": "ssl-env-test-org"})
+        for key in self._CA_BUNDLE_KEYS:
+            self.assertNotIn(key, resource_data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/plugins/plugin_utils/manager/test_merge_manager_environment.py
+++ b/tests/unit/plugins/plugin_utils/manager/test_merge_manager_environment.py
@@ -1,0 +1,67 @@
+# (c) 2026 Red Hat Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Tests for inventory CA bundle forwarding in manager subprocess environment."""
+
+from __future__ import absolute_import, division, print_function
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+_COLLECTIONS_PARENT = str(Path(__file__).resolve().parent.parent.parent.parent.parent.parent.parent)
+if _COLLECTIONS_PARENT not in sys.path:
+    sys.path.insert(0, _COLLECTIONS_PARENT)
+
+from ansible_collections.ansible.platform.plugins.plugin_utils.manager.process_manager import ProcessManager  # noqa: E402
+from ansible_collections.ansible.platform.plugins.plugin_utils.platform.config import GatewayConfig  # noqa: E402
+
+
+class TestMergeManagerEnvironment(unittest.TestCase):
+    def _config(self, **kwargs):
+        defaults = {
+            "base_url": "https://gw.example",
+            "verify_ssl": True,
+            "ca_bundle": None,
+        }
+        defaults.update(kwargs)
+        return GatewayConfig(**defaults)
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_inventory_ca_bundle_sets_requests_ca_bundle(self):
+        env = ProcessManager.merge_manager_environment(
+            self._config(ca_bundle="/tmp/inventory-ca.pem"),
+        )
+        self.assertEqual(env["REQUESTS_CA_BUNDLE"], "/tmp/inventory-ca.pem")
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_task_env_overrides_inventory_ca_bundle(self):
+        env = ProcessManager.merge_manager_environment(
+            self._config(ca_bundle="/tmp/inventory-ca.pem"),
+            task_env={"REQUESTS_CA_BUNDLE": "/tmp/task-ca.pem"},
+        )
+        self.assertEqual(env["REQUESTS_CA_BUNDLE"], "/tmp/task-ca.pem")
+
+    @patch.dict("os.environ", {"REQUESTS_CA_BUNDLE": "/tmp/shell-ca.pem"}, clear=True)
+    def test_existing_shell_env_overrides_inventory_ca_bundle(self):
+        env = ProcessManager.merge_manager_environment(
+            self._config(ca_bundle="/tmp/inventory-ca.pem"),
+        )
+        self.assertEqual(env["REQUESTS_CA_BUNDLE"], "/tmp/shell-ca.pem")
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_ca_bundle_not_applied_when_verify_disabled(self):
+        env = ProcessManager.merge_manager_environment(
+            self._config(ca_bundle="/tmp/inventory-ca.pem", verify_ssl=False),
+        )
+        self.assertNotIn("REQUESTS_CA_BUNDLE", env)
+
+    @patch.dict("os.environ", {"SSL_CERT_FILE": "/tmp/legacy-ca.pem"}, clear=True)
+    def test_ssl_cert_file_shim_still_applies(self):
+        env = ProcessManager.merge_manager_environment(self._config())
+        self.assertEqual(env["REQUESTS_CA_BUNDLE"], "/tmp/legacy-ca.pem")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/plugins/plugin_utils/manager/test_merge_manager_environment.py
+++ b/tests/unit/plugins/plugin_utils/manager/test_merge_manager_environment.py
@@ -50,6 +50,14 @@ class TestMergeManagerEnvironment(unittest.TestCase):
         )
         self.assertEqual(env["REQUESTS_CA_BUNDLE"], "/tmp/shell-ca.pem")
 
+    @patch.dict("os.environ", {"REQUESTS_CA_BUNDLE": "/tmp/shell-ca.pem"}, clear=True)
+    def test_existing_shell_env_overrides_task_env_for_requests_ca_bundle(self):
+        env = ProcessManager.merge_manager_environment(
+            self._config(ca_bundle="/tmp/inventory-ca.pem"),
+            task_env={"REQUESTS_CA_BUNDLE": "/tmp/task-ca.pem"},
+        )
+        self.assertEqual(env["REQUESTS_CA_BUNDLE"], "/tmp/shell-ca.pem")
+
     @patch.dict("os.environ", {}, clear=True)
     def test_ca_bundle_not_applied_when_verify_disabled(self):
         env = ProcessManager.merge_manager_environment(

--- a/tests/unit/plugins/plugin_utils/test_extract_gateway_config_aliases.py
+++ b/tests/unit/plugins/plugin_utils/test_extract_gateway_config_aliases.py
@@ -178,5 +178,69 @@ class TestRequestTimeoutAliases(unittest.TestCase):
         self.assertEqual(cfg.request_timeout, 10.0)
 
 
+class TestCaBundleAliases(unittest.TestCase):
+    """aap_ca_bundle / gateway_ca_bundle / ansible_platform_ca_bundle aliases."""
+
+    def test_aap_ca_bundle_from_task_args(self):
+        cfg = extract_gateway_config(
+            task_args={**_BASE, "aap_ca_bundle": "/tmp/custom-ca.pem"},
+            host_vars={},
+        )
+        self.assertEqual(cfg.ca_bundle, "/tmp/custom-ca.pem")
+
+    def test_gateway_ca_bundle_alias(self):
+        cfg = extract_gateway_config(
+            task_args={**_BASE, "gateway_ca_bundle": "/tmp/gateway-ca.pem"},
+            host_vars={},
+        )
+        self.assertEqual(cfg.ca_bundle, "/tmp/gateway-ca.pem")
+
+    def test_ansible_platform_ca_bundle_alias(self):
+        cfg = extract_gateway_config(
+            task_args={**_BASE, "ansible_platform_ca_bundle": "/tmp/platform-ca.pem"},
+            host_vars={},
+        )
+        self.assertEqual(cfg.ca_bundle, "/tmp/platform-ca.pem")
+
+    def test_task_args_override_host_vars(self):
+        cfg = extract_gateway_config(
+            task_args={**_BASE, "aap_ca_bundle": "/tmp/task-ca.pem"},
+            host_vars={"gateway_ca_bundle": "/tmp/host-ca.pem"},
+        )
+        self.assertEqual(cfg.ca_bundle, "/tmp/task-ca.pem")
+
+    def test_host_vars_used_when_not_in_task_args(self):
+        cfg = extract_gateway_config(
+            task_args=dict(_BASE),
+            host_vars={"aap_ca_bundle": "/tmp/inventory-ca.pem"},
+        )
+        self.assertEqual(cfg.ca_bundle, "/tmp/inventory-ca.pem")
+
+    def test_aap_ca_bundle_takes_priority_over_aliases(self):
+        cfg = extract_gateway_config(
+            task_args={**_BASE, "aap_ca_bundle": "/tmp/primary.pem", "gateway_ca_bundle": "/tmp/legacy.pem"},
+            host_vars={},
+        )
+        self.assertEqual(cfg.ca_bundle, "/tmp/primary.pem")
+
+    def test_default_is_none_when_not_set(self):
+        cfg = extract_gateway_config(task_args=dict(_BASE), host_vars={})
+        self.assertIsNone(cfg.ca_bundle)
+
+    def test_requests_verify_uses_ca_bundle_when_verify_enabled(self):
+        cfg = extract_gateway_config(
+            task_args={**_BASE, "aap_ca_bundle": "/tmp/custom-ca.pem", "aap_validate_certs": True},
+            host_vars={},
+        )
+        self.assertEqual(cfg.requests_verify, "/tmp/custom-ca.pem")
+
+    def test_requests_verify_false_when_validate_certs_disabled(self):
+        cfg = extract_gateway_config(
+            task_args={**_BASE, "aap_ca_bundle": "/tmp/custom-ca.pem", "aap_validate_certs": False},
+            host_vars={},
+        )
+        self.assertFalse(cfg.requests_verify)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Add inventory/task variable `aap_ca_bundle` (aliases `gateway_ca_bundle`, `ansible_platform_ca_bundle`) resolved in `extract_gateway_config()`.
- Forward the control-node CA bundle path to manager subprocesses as `REQUESTS_CA_BUNDLE` when `aap_validate_certs` is enabled, so private/enterprise CA chains work without per-task `environment:` blocks or system trust store changes.
- Use `GatewayConfig.requests_verify` for `requests` / direct HTTP clients (bool, path, or disabled).

Supports the containerized installer strategy in [ANSTRAT-2452](https://redhat.atlassian.net/browse/ANSTRAT-2452): installer slurps trust material from the gateway inventory host, writes a bundle on the install node, and sets `aap_ca_bundle` for platform collection tasks.

## Test plan

- [x] Unit: `extract_gateway_config()` alias resolution and `requests_verify` behavior
- [x] Unit: `ProcessManager.merge_manager_environment()` precedence (shell env > task env > inventory var)
- [x] Integration: extend `ssl_env_forwarding_test` with TEST 4 (inventory `aap_ca_bundle=/dev/null` → SSL error) and TEST 5 (inventory `aap_ca_bundle=<real CA>` → success)
- [ ] Installer E2E (aap-containerized-installer team, tracked separately under ANSTRAT-2452)

## Precedence

`REQUESTS_CA_BUNDLE` resolution for manager subprocesses:

1. Control-node shell environment
2. Task/play `environment:` block
3. Inventory `aap_ca_bundle` when `aap_validate_certs: true`
4. Deprecated `SSL_CERT_FILE` shim


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom CA bundle for certificate validation.
  * Added documented aliases and precedence rules for CA bundle settings.
  * Forwarded the configured CA bundle to manager processes when TLS verification is enabled.

* **Bug Fixes**
  * Standardized CA bundle and TLS verification handling across API requests and connections.
  * Preserved compatibility with the legacy `SSL_CERT_FILE` environment setting.

* **Documentation**
  * Documented CA bundle configuration, aliases, validation behavior, and environment forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->