### PR TITLE
Document SDK execution invariants and CI guard for action plugins

### DIFF
--- a/.claude/skills/platform-onboarding/SKILL.md
+++ b/.claude/skills/platform-onboarding/SKILL.md
@@ -154,7 +154,7 @@ plugins/
   action/              # Action plugins (one per resource entity)
     base_action.py     # Base class — ALL action plugins inherit from this
     organization.py    # Pattern A: 3 lines (simplest)
-    user.py            # Pattern C: fully custom (most complex)
+    user.py            # Pattern C: thin run() orchestration (still uses manager.execute())
   modules/             # Module doc stubs (DOCUMENTATION + EXAMPLES only)
   connection/
     http.py            # Connection plugin — persistent vs direct mode routing
@@ -189,9 +189,10 @@ Read `docs/07-adding-resources.md` briefly and explain:
   `organization.py`. Used when fields map 1:1 to API.
 - **Pattern B** (hook-based): Overrides specific hooks (`_pre_create`,
   `_post_update`). Used when you need side effects or extra validation.
-- **Pattern C** (fully custom): Overrides `execute()` entirely. Example:
-  `user.py`. Used for complex resources with write-only fields, multiple
-  endpoints, or non-standard workflows.
+- **Pattern C** (orchestration): Overrides `run()` for multi-step workflows that still
+  call `manager.execute()` only. Example: `user.py`. **Not** for HTTP, associations,
+  or secondary endpoints — those belong in the transform mixin (see
+  `docs/09-agent-collaboration.md` §10 and `docs/07-adding-resources.md` §4a).
 
 ### Exercise 3
 
@@ -356,6 +357,7 @@ After all five phases, the engineer should be able to answer:
 - [ ] How does the persistent manager subprocess work?
 - [ ] Where do action plugins, ansible models, and API models live in the tree?
 - [ ] What are the three plugin patterns (A, B, C) and when to use each?
+- [ ] What are the SDK execution invariants (no HTTP in action plugins; MCP parity)?
 - [ ] What are the seven files needed for a new resource module?
 - [ ] How to run unit tests, Molecule tests, and integration tests?
 - [ ] What's the PR workflow (Jira reference, labels, approvals, CasC)?
@@ -398,3 +400,7 @@ For deeper dives beyond onboarding, point the engineer to:
 - **Verify endpoint paths match the service type.** EDA uses `/api/eda/v1/`,
   not `/api/gateway/v1/`. This is the single most common mistake when adding
   non-Gateway modules. The generator handles this automatically.
+- **Never add HTTP to action plugins.** No `manager.session`, no `import requests`.
+  Associations, surveys, and copy workflows go in the transform mixin so MCP (#206)
+  and other SDK consumers stay in parity. Run `make check_action_plugin_invariants`.
+  Read `docs/09-agent-collaboration.md` §10 before customizing `plugins/action/`.

--- a/.claude/skills/platform-onboarding/SKILL.md
+++ b/.claude/skills/platform-onboarding/SKILL.md
@@ -404,3 +404,5 @@ For deeper dives beyond onboarding, point the engineer to:
   Associations, surveys, and copy workflows go in the transform mixin so MCP (#206)
   and other SDK consumers stay in parity. Run `make check_action_plugin_invariants`.
   Read `docs/09-agent-collaboration.md` §10 before customizing `plugins/action/`.
+- **Never poll job status in action plugins.** `wait` / `interval` / `timeout` belong in
+  `PlatformService.execute()` (see `docs/07-adding-resources.md` §4c and PR #227).

--- a/.claude/skills/platform-onboarding/references/cheatsheet.md
+++ b/.claude/skills/platform-onboarding/references/cheatsheet.md
@@ -59,19 +59,25 @@ class ActionModule(BaseResourceActionPlugin):
 Available hooks: `_pre_create`, `_post_create`, `_pre_update`, `_post_update`,
 `_pre_delete`, `_post_delete`, `_custom_exists`.
 
-### Pattern C — Fully Custom
+### Pattern C — Orchestration-only custom `run()`
 
-Use when: Complex resources with write-only fields, multiple endpoints,
-or non-standard workflows.
+Use when: Multi-step Ansible workflows that still delegate all HTTP to the SDK
+(for example `user.py`, `role_team_assignment.py`).
+
+**Do not** use Pattern C to add `manager.session` HTTP, association sub-endpoints,
+or survey/copy logic — put that in the transform mixin
+([05-design-principles.md §3a](../../docs/05-design-principles.md)).
 
 ```python
 class ActionModule(BaseResourceActionPlugin):
-    resource_type = "user"
+    MODULE_NAME = "user"
+    MODEL_CLASS = AnsibleUser
+    _WRITE_ONLY_FIELDS = frozenset({"update_secrets"})
 
-    def execute(self, operation, ansible_data):
-        # Full custom logic — handle password (write-only),
-        # multi-org assignment, etc.
-        ...
+    def run(self, tmp=None, task_vars=None):
+        # Orchestrate multiple manager.execute() calls if needed.
+        # All HTTP stays in PlatformService — required for MCP (#206) parity.
+        return super().run(tmp, task_vars)
 ```
 
 ---
@@ -140,7 +146,7 @@ class FooTransformMixin_v1:
 
 - No custom logic needed → Pattern A (3 lines)
 - Need hooks → Pattern B
-- Complex resource → Pattern C
+- Need multi-step orchestration via `manager.execute()` → Pattern C (not HTTP in action plugin)
 
 ### Step 5–7: Tests
 
@@ -164,6 +170,9 @@ molecule test -s <resource>_mock
 
 # Run linting
 ansible-test sanity --docker -v
+
+# Verify action plugins do not call HTTP directly
+make check_action_plugin_invariants
 
 # Check registry discovers your module
 python -c "

--- a/.claude/skills/platform-onboarding/references/cheatsheet.md
+++ b/.claude/skills/platform-onboarding/references/cheatsheet.md
@@ -171,7 +171,7 @@ molecule test -s <resource>_mock
 # Run linting
 ansible-test sanity --docker -v
 
-# Verify action plugins do not call HTTP directly
+# Verify action plugins do not call HTTP directly or poll job status
 make check_action_plugin_invariants
 
 # Check registry discovers your module

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -24,6 +24,8 @@ jobs:
             command: check_mypy
           - name: pydoclint
             command: check_pydoclint
+          - name: action-plugin-invariants
+            command: check_action_plugin_invariants
     steps:
       - name: Install make
         run: sudo apt install make

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,5 +27,14 @@ See [`docs/`](docs/) for architecture, coding standards, testing strategy, and t
 
 Before changing `plugins/action/` or adding controller/awx migrations, read
 [`docs/09-agent-collaboration.md`](docs/09-agent-collaboration.md) §10 (SDK execution
-invariants). Run `make check_action_plugin_invariants` before opening a PR. Resource
-logic belongs in transform mixins so playbooks, MCP, and other SDK consumers share one path.
+invariants) and [`docs/07-adding-resources.md`](docs/07-adding-resources.md) §4c (launch/job
+wait). Run `make check_action_plugin_invariants` before opening a PR. Resource logic belongs
+in transform mixins and `PlatformService.execute()` so playbooks, MCP, and other SDK
+consumers share one path.
+
+**Checklist for controller migrations and launch modules:**
+
+- [ ] No `manager.session` or `requests` in action plugins (`make check_action_plugin_invariants`)
+- [ ] No wait/poll loops (`time.sleep`, `_wait_for_*`) in action plugins — use PlatformService
+- [ ] Every option in module `DOCUMENTATION` (including `wait`, `interval`, `timeout`) works via
+      `PlatformService.execute()`, not only through the action plugin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,3 +22,10 @@ If your change adds a module, alters auth or return values, or deprecates anythi
 ---
 
 See [`docs/`](docs/) for architecture, coding standards, testing strategy, and the full module workflow.
+
+### AI agents and automated contributors
+
+Before changing `plugins/action/` or adding controller/awx migrations, read
+[`docs/09-agent-collaboration.md`](docs/09-agent-collaboration.md) §10 (SDK execution
+invariants). Run `make check_action_plugin_invariants` before opening a PR. Resource
+logic belongs in transform mixins so playbooks, MCP, and other SDK consumers share one path.

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ check_mypy:
 check_pydoclint:
 	tox -e pydoclint
 
-## Fail if action plugins contain direct HTTP (manager.session, requests, etc.)
+## Fail if action plugins contain direct HTTP or Ansible-only wait/poll logic
 check_action_plugin_invariants:
 	@bash tools/check_action_plugin_invariants.sh
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PYTHON_VERSION:
 	@echo "$(subst python,,$(PYTHON))"
 
 .PHONY: PYTHON_VERSION clean git_hooks_config \
-	check_ruff check_mypy check_pydoclint \
+	check_ruff check_mypy check_pydoclint check_action_plugin_invariants \
 	collection-install collection-test collection-docs \
 	collection-lint collection-sanity  collection-test-completeness \
 	collection-test-integration-check \
@@ -41,6 +41,10 @@ check_mypy:
 ## Run pydoclint docstring style check
 check_pydoclint:
 	tox -e pydoclint
+
+## Fail if action plugins contain direct HTTP (manager.session, requests, etc.)
+check_action_plugin_invariants:
+	@bash tools/check_action_plugin_invariants.sh
 
 ## Install the collection locally on your machine
 collection-install:

--- a/changelogs/fragments/sdk_execution_invariants_docs.yml
+++ b/changelogs/fragments/sdk_execution_invariants_docs.yml
@@ -1,0 +1,7 @@
+---
+doc_changes:
+  - docs - Document SDK execution invariants so resource logic stays in transform
+    mixins and PlatformService.execute(), preserving parity for MCP and other
+    non-Ansible SDK consumers. Update agent onboarding skill and add CI check for
+    HTTP in action plugins.
+...

--- a/changelogs/fragments/sdk_execution_invariants_docs.yml
+++ b/changelogs/fragments/sdk_execution_invariants_docs.yml
@@ -2,6 +2,7 @@
 doc_changes:
   - docs - Document SDK execution invariants so resource logic stays in transform
     mixins and PlatformService.execute(), preserving parity for MCP and other
-    non-Ansible SDK consumers. Update agent onboarding skill and add CI check for
-    HTTP in action plugins.
+    non-Ansible SDK consumers. Add invariant 7 (wait/poll in PlatformService),
+    launch-module guidance (§4c, cross-ref PR 227), and CI checks for HTTP and
+    Ansible-only poll loops in action plugins.
 ...

--- a/docs/05-design-principles.md
+++ b/docs/05-design-principles.md
@@ -85,6 +85,35 @@ scattered across the action plugin.
 
 ---
 
+## SECTION 3a: Principle — SDK Consumer Parity (Single Execution Path)
+
+**Rule**: Every resource capability exposed in module `DOCUMENTATION` must be reachable
+through `PlatformService.execute(operation, module_name, params)` inside the manager
+process. Action plugins, MCP servers, CLIs, and other SDK consumers must not diverge.
+
+**Why**: Non-Ansible consumers (for example the MCP server in
+[#206](https://github.com/ansible/ansible.platform/pull/206)) discover tools from module
+metadata and call `PlatformService.execute()` directly — they do not import action plugins.
+Logic trapped in a custom action plugin (especially direct `manager.session` HTTP) is
+**Ansible-only** and breaks parity across consumers.
+
+**What this means in practice**:
+
+| Need | Implement in | Action plugin |
+|------|----------------|---------------|
+| Field mapping, FK resolution | Transform mixin | Pattern A (default) |
+| Associations, surveys, copy, secondary endpoints | Mixin `get_endpoint_operations()` / hooks | Pattern B hooks only |
+| Multi-step Ansible orchestration | Thin custom `run()` calling `manager.execute()` | Pattern C |
+
+**Test**: If MCP `execute` mode (or a standalone SDK script) cannot perform the same
+operation as a playbook task, the implementation belongs in the SDK layer, not the
+action plugin.
+
+See [09-agent-collaboration.md](09-agent-collaboration.md) §10 for agent invariants and
+`make check_action_plugin_invariants` for CI enforcement.
+
+---
+
 ## SECTION 4: Principle 4 — Registry Auto-Discovery
 
 **Rule**: New API versions are added by creating a new directory `plugins/plugin_utils/api/v<N>/`.
@@ -513,6 +542,7 @@ matching must be designed. (See: Principle 2 in `04-data-model-transformation.md
 | 12. Consistent env var types | Env vars accept same types as config | User experience |
 | 13. Quality checklist | Verify all items before merge | Consistency |
 | 14. Human-in-the-loop | Stop on key/secondary/nested/conditional fields | Safety |
+| 15. SDK consumer parity | All behavior via `PlatformService.execute()` | Multi-consumer architecture |
 
 ---
 

--- a/docs/05-design-principles.md
+++ b/docs/05-design-principles.md
@@ -103,11 +103,14 @@ Logic trapped in a custom action plugin (especially direct `manager.session` HTT
 |------|----------------|---------------|
 | Field mapping, FK resolution | Transform mixin | Pattern A (default) |
 | Associations, surveys, copy, secondary endpoints | Mixin `get_endpoint_operations()` / hooks | Pattern B hooks only |
+| Launch/job wait (`wait`, `interval`, `timeout`) | `PlatformService.execute()` + shared poller | Pattern A (pass-through) |
 | Multi-step Ansible orchestration | Thin custom `run()` calling `manager.execute()` | Pattern C |
 
 **Test**: If MCP `execute` mode (or a standalone SDK script) cannot perform the same
 operation as a playbook task, the implementation belongs in the SDK layer, not the
-action plugin.
+action plugin. A launch module that documents `wait: true` but only polls in the action
+plugin fails this test — see
+[#227](https://github.com/ansible/ansible.platform/pull/227).
 
 See [09-agent-collaboration.md](09-agent-collaboration.md) §10 for agent invariants and
 `make check_action_plugin_invariants` for CI enforcement.

--- a/docs/07-adding-resources.md
+++ b/docs/07-adding-resources.md
@@ -379,6 +379,37 @@ CLI tools share one implementation.
 
 ---
 
+## SECTION 4c: Launch and Job Modules (Wait / Poll)
+
+Controller launch modules (`ad_hoc_command`, future `job_launch`, `project_update`, etc.)
+POST a job-like resource and optionally block until completion. These are **not** CRUD
+resources — every invocation creates a new execution — but they still must obey SDK
+consumer parity ([#206](https://github.com/ansible/ansible.platform/pull/206)).
+
+**Do**:
+
+- Document `wait`, `interval`, and `timeout` in module `DOCUMENTATION` when parity with
+  `awx.awx` / `ansible.controller` requires them.
+- Implement wait semantics in **`PlatformService.execute()`**: pop action-only params
+  before instantiating the Ansible dataclass, call create via the mixin, then poll with a
+  **shared** SDK helper (mixin hooks supply `is_finished()` / failure status rules).
+- Keep the action plugin thin — Pattern A is enough when the SDK handles launch + wait.
+
+**Do not**:
+
+- Add `_wait_for_completion()` or `time.sleep()` poll loops in `plugins/action/`. MCP and
+  other SDK consumers never import action plugins; wait logic there is Ansible-only.
+- Treat a correct `manager.execute()` launch as sufficient when `wait` is documented but
+  unimplemented in the SDK — that breaks MCP `execute` mode while playbooks appear to work.
+
+**Reference**: [#227](https://github.com/ansible/ansible.platform/pull/227) ports
+`ad_hoc_command` with solid mixin/transform coverage but places wait/poll in the action
+plugin — a documentation and placement miss, not a direct-HTTP violation like
+[#228](https://github.com/ansible/ansible.platform/pull/228). Guidance and CI checks are
+added in [#239](https://github.com/ansible/ansible.platform/pull/239).
+
+---
+
 ## SECTION 4b: Document Fragment Registration (`plugins/doc_fragments/`)
 
 If your resource introduces a new connection-level or authentication option (like `gateway_idle_timeout`), it must be registered in the documentation fragment so it appears in `ansible-doc` output.

--- a/docs/07-adding-resources.md
+++ b/docs/07-adding-resources.md
@@ -345,6 +345,40 @@ class ActionModule(BaseResourceActionPlugin):
 
 ---
 
+## SECTION 4a: Secondary Endpoints, Associations, and Controller Resources
+
+When a resource needs behavior beyond a single CRUD endpoint — association sub-resources
+(`credentials`, `labels`, `instance_groups`), secondary endpoints (`survey_spec`),
+copy workflows (`copy_from`), or controller-service paths (`/api/controller/v2/`) —
+implement that logic in the **transform mixin** and `PlatformService`, not in the action
+plugin.
+
+**Do**:
+
+- Declare secondary operations in `get_endpoint_operations()` (see [Common Patterns
+  Catalog — Pattern 6](#pattern-6-secondary-endpoint-post-create-operation)).
+- Resolve association names to IDs in `from_ansible_data()` using
+  `context.manager.lookup_resource_id()`.
+- Keep write-only / side-effect parameters in `_WRITE_ONLY_FIELDS` on the action plugin
+  so they are stripped before model instantiation.
+- Use Pattern B hooks (`_pre_execute_hook`, `_post_create`) only to orchestrate
+  **additional `manager.execute()` calls** when the SDK requires multiple steps.
+
+**Do not**:
+
+- Call `manager.session.get/post/delete` from `plugins/action/` (forbidden — see
+  [05-design-principles.md](05-design-principles.md) §1 and §3a).
+- Hardcode API paths in the action plugin; paths belong in the mixin / registry layer.
+- Add a large custom `run()` to implement HTTP that MCP and other SDK consumers cannot
+  reach (see [09-agent-collaboration.md](09-agent-collaboration.md) §10).
+
+Controller migrations from `awx.awx` / `ansible.controller` often need this section:
+awx modules historically bundled association and survey logic in the module/action layer.
+In `ansible.platform`, that parity work belongs in the SDK so playbooks, MCP, and future
+CLI tools share one implementation.
+
+---
+
 ## SECTION 4b: Document Fragment Registration (`plugins/doc_fragments/`)
 
 If your resource introduces a new connection-level or authentication option (like `gateway_idle_timeout`), it must be registered in the documentation fragment so it appears in `ansible-doc` output.

--- a/docs/09-agent-collaboration.md
+++ b/docs/09-agent-collaboration.md
@@ -505,6 +505,36 @@ Which documents to read for which task:
 
 ---
 
+## SECTION 10: SDK Execution Invariants (Agents and Contributors)
+
+These invariants complement [05-design-principles.md](05-design-principles.md). Violating
+them produces Ansible-only modules that break MCP and other SDK consumers
+(see [#206](https://github.com/ansible/ansible.platform/pull/206)).
+
+1. **Single execution path** — All API behavior must be reachable via
+   `PlatformService.execute(operation, module_name, params)`.
+2. **No network I/O in action plugins** — Forbidden in `plugins/action/`:
+   `import requests`, `manager.session`, `session.get/post/delete/patch`, and hardcoded
+   API URL strings used for HTTP.
+3. **Secondary endpoints live in the mixin** — Associations, surveys, copy workflows, and
+   sub-resources belong in `get_endpoint_operations()`, mixin hooks, and
+   `TransformContext.manager` — not in the action plugin.
+4. **Pattern selection** — Default to Pattern A. Use Pattern B hooks for orchestration.
+   Pattern C means a thin custom `run()` that calls `manager.execute()` multiple times —
+   **not** new HTTP in the action plugin.
+5. **SDK consumer parity** — If a playbook task accepts a module option, MCP `execute`
+   mode must be able to apply it without importing action plugins.
+6. **Review gate** — If an action plugin exceeds ~50 lines or references `manager.session`,
+   stop and move logic into the transform mixin / `PlatformService`.
+
+CI enforces invariant 2 locally and in PR checks:
+
+```bash
+make check_action_plugin_invariants
+```
+
+---
+
 ## SECTION 11: Do Not — Anti-Patterns to Avoid
 
 Stop the agent immediately if it attempts any of these:
@@ -513,15 +543,21 @@ Stop the agent immediately if it attempts any of these:
 
 **Wrong:**
 ```python
-# plugins/action/user.py
+# plugins/action/job_template.py
 import requests
-
 
 def run(self):
     response = requests.post("http://...")  # NO!
+
+# Also wrong — bypasses PlatformService.execute() and breaks MCP (#206)
+def _handle_associations(self, manager, jt_id, ...):
+    manager.session.get(manager._build_url("/api/controller/v2/..."))
+    manager.session.post(...)
 ```
 
-**Right:** All HTTP lives in PlatformService inside the manager process. Action plugins call `manager.execute()` only.
+**Right:** All HTTP lives in PlatformService inside the manager process. Action plugins
+call `manager.execute()` and `manager.lookup_resource_id()` only. Put association,
+survey, and copy logic in the transform mixin.
 
 ---
 

--- a/docs/09-agent-collaboration.md
+++ b/docs/09-agent-collaboration.md
@@ -524,10 +524,18 @@ them produces Ansible-only modules that break MCP and other SDK consumers
    **not** new HTTP in the action plugin.
 5. **SDK consumer parity** — If a playbook task accepts a module option, MCP `execute`
    mode must be able to apply it without importing action plugins.
-6. **Review gate** — If an action plugin exceeds ~50 lines or references `manager.session`,
+6. **Review gate** — If an action plugin exceeds ~50 lines, references `manager.session`,
+   implements a poll loop, or fully overrides `run()` without delegating to the base class,
    stop and move logic into the transform mixin / `PlatformService`.
+7. **Wait and poll in PlatformService** — Module options such as `wait`, `interval`, and
+   `timeout` (common on launch/job controller modules) must be handled inside
+   `PlatformService.execute()` — pop them before building the Ansible dataclass, launch via
+   the mixin, then poll with a **shared** SDK helper. Action plugins must not define
+   `_wait_for_completion()` or use `time.sleep()` to poll job status. MCP and other SDK
+   consumers call `execute()` only; wait logic trapped in an action plugin is Ansible-only
+   (see [#227](https://github.com/ansible/ansible.platform/pull/227) for a concrete example).
 
-CI enforces invariant 2 locally and in PR checks:
+CI enforces invariants 2 and 7 locally and in PR checks:
 
 ```bash
 make check_action_plugin_invariants
@@ -561,7 +569,30 @@ survey, and copy logic in the transform mixin.
 
 ---
 
-### 2. Do not hardcode version lists
+### 2. Do not implement wait/poll loops in action plugins
+
+**Wrong:**
+```python
+# plugins/action/ad_hoc_command.py — Ansible-only; MCP cannot wait (#227)
+def _wait_for_completion(self, manager, command_id, ...):
+    while True:
+        response = manager.execute(operation="find", ...)
+        if response.get("finished"):
+            return response.get("status")
+        time.sleep(interval)
+```
+
+**Right:** Pop `wait` / `interval` / `timeout` in `PlatformService.execute()`, launch via
+the transform mixin, then call a shared `wait_for_completion()` helper in the SDK. The
+action plugin stays thin (Pattern A or B) or passes params through without polling.
+See [07-adding-resources.md](07-adding-resources.md) §4c.
+
+This is a **documentation and placement** issue, not a ban on `manager.execute()` — #227
+uses the SDK path correctly for HTTP but places wait semantics where MCP cannot see them.
+
+---
+
+### 3. Do not hardcode version lists
 
 **Wrong:**
 ```python
@@ -572,7 +603,7 @@ SUPPORTED_VERSIONS = ["1", "2"]
 
 ---
 
-### 3. Do not skip doc_fragments for new options
+### 4. Do not skip doc_fragments for new options
 
 **Wrong:**
 ```python
@@ -584,7 +615,7 @@ SUPPORTED_VERSIONS = ["1", "2"]
 
 ---
 
-### 4. Do not use `int()` directly on environment variables
+### 5. Do not use `int()` directly on environment variables
 
 **Wrong:**
 ```python
@@ -600,7 +631,7 @@ The float intermediary prevents `int()` from choking on scientific notation or e
 
 ---
 
-### 5. Do not compare names to IDs for reference fields
+### 6. Do not compare names to IDs for reference fields
 
 **Wrong:**
 ```python
@@ -621,7 +652,7 @@ See Design Principle 7.
 
 ---
 
-### 6. Do not forget write-only fields in idempotency
+### 7. Do not forget write-only fields in idempotency
 
 **Wrong:**
 ```python
@@ -640,7 +671,7 @@ if ansible_instance.password is not None:
 
 ---
 
-### 7. Do not use `fields_to_null` without understanding AAP semantics
+### 8. Do not use `fields_to_null` without understanding AAP semantics
 
 **Wrong:**
 ```python

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,8 @@ Start with [07-adding-resources.md](07-adding-resources.md) to add a new platfor
 
 ### For AI Agents
 
-Load [09-agent-collaboration.md](09-agent-collaboration.md) first to understand personas, phases, and quality gates.
+Load [09-agent-collaboration.md](09-agent-collaboration.md) first — especially **§10 SDK
+execution invariants** — to understand personas, phases, and quality gates.
 
 ---
 
@@ -36,7 +37,7 @@ Load [09-agent-collaboration.md](09-agent-collaboration.md) first to understand 
 | 02 | [02-action-plugin-pattern.md](02-action-plugin-pattern.md) | All | States (present/absent/exists/enforced), entities vs endpoints, convergence contract |
 | 03 | [03-sdk-architecture.md](03-sdk-architecture.md) | Architects / Senior devs | Persistent connection manager, two connection modes, RPC interface, directory structure |
 | 04 | [04-data-model-transformation.md](04-data-model-transformation.md) | Framework devs | Three-tier data flow, Ansible model, API model, transform mixin, ref fields, case studies |
-| 05 | [05-design-principles.md](05-design-principles.md) | All devs | 10 rules governing every decision, quality checklist, human-in-the-loop triggers |
+| 05 | [05-design-principles.md](05-design-principles.md) | All devs | Design rules, SDK consumer parity, quality checklist, human-in-the-loop triggers |
 | 06 | [06-foundation-components.md](06-foundation-components.md) | Framework devs | Full spec: Registry, Loader, BaseTransformMixin, GatewayConfig, PlatformService, PlatformManager, ManagerRPCClient, BaseResourceActionPlugin |
 | 07 | [07-adding-resources.md](07-adding-resources.md) | Feature devs | Step-by-step 7-file workflow, complete example, common patterns catalog, PR checklist |
 | 08 | [08-testing-strategy.md](08-testing-strategy.md) | All devs / QE | Three-layer strategy: unit (pytest), Molecule mock, integration; CI workflows; linting |

--- a/tools/check_action_plugin_invariants.sh
+++ b/tools/check_action_plugin_invariants.sh
@@ -5,19 +5,15 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ACTION_DIR="${ROOT}/plugins/action"
-
-if ! command -v rg >/dev/null 2>&1; then
-    echo "ERROR: ripgrep (rg) is required to run check_action_plugin_invariants" >&2
-    exit 1
-fi
-
 PATTERN='manager\.session|import requests|from requests import|from requests\.'
 
-if rg -q "${PATTERN}" "${ACTION_DIR}"; then
+MATCHES="$(grep -R -n -E "${PATTERN}" "${ACTION_DIR}" --include='*.py' 2>/dev/null || true)"
+
+if [[ -n "${MATCHES}" ]]; then
     echo "ERROR: Action plugins must not perform HTTP directly." >&2
     echo "Use PlatformService.execute() and transform mixins instead." >&2
     echo "See docs/09-agent-collaboration.md section 10." >&2
-    rg -n "${PATTERN}" "${ACTION_DIR}" >&2 || true
+    printf '%s\n' "${MATCHES}" >&2
     exit 1
 fi
 

--- a/tools/check_action_plugin_invariants.sh
+++ b/tools/check_action_plugin_invariants.sh
@@ -1,19 +1,76 @@
 #!/usr/bin/env bash
-# Enforce SDK execution invariants: no HTTP in action plugins.
+# Enforce SDK execution invariants in action plugins.
 # See docs/09-agent-collaboration.md §10 and docs/05-design-principles.md §3a.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ACTION_DIR="${ROOT}/plugins/action"
-PATTERN='manager\.session|import requests|from requests import|from requests\.'
 
-MATCHES="$(grep -R -n -E "${PATTERN}" "${ACTION_DIR}" --include='*.py' 2>/dev/null || true)"
+if [[ ! -d "${ACTION_DIR}" ]]; then
+    echo "ERROR: Action plugin directory not found: ${ACTION_DIR}" >&2
+    exit 1
+fi
 
-if [[ -n "${MATCHES}" ]]; then
+# grep -R: status 0 = match, 1 = no match, 2+ = error (fail closed).
+grep_action_plugins() {
+    local pattern="$1"
+    local matches=""
+    local status=0
+    matches="$(grep -R -n -E "${pattern}" "${ACTION_DIR}" --include='*.py' 2>/dev/null)" || status=$?
+    if [[ "${status}" -ge 2 ]]; then
+        echo "ERROR: Failed to scan ${ACTION_DIR} for pattern: ${pattern}" >&2
+        exit 1
+    fi
+    if [[ -n "${matches}" ]]; then
+        printf '%s\n' "${matches}"
+    fi
+}
+
+# Invariant 2: no direct HTTP in action plugins.
+HTTP_PATTERN='manager\.session|import requests|from requests import|from requests\.'
+HTTP_MATCHES="$(grep_action_plugins "${HTTP_PATTERN}")"
+
+if [[ -n "${HTTP_MATCHES}" ]]; then
     echo "ERROR: Action plugins must not perform HTTP directly." >&2
     echo "Use PlatformService.execute() and transform mixins instead." >&2
-    echo "See docs/09-agent-collaboration.md section 10." >&2
-    printf '%s\n' "${MATCHES}" >&2
+    echo "See docs/09-agent-collaboration.md section 10 (invariant 2)." >&2
+    printf '%s\n' "${HTTP_MATCHES}" >&2
+    exit 1
+fi
+
+# Invariant 7: job wait/poll logic belongs in PlatformService, not action plugins.
+# base_action.py may use time.sleep for process lifecycle (not API polling).
+POLL_PATTERN='_wait_for|wait_for_completion'
+sleep_action_plugins() {
+    local matches=""
+    local status=0
+    matches="$(grep -R -n -E 'time\.sleep' "${ACTION_DIR}" --include='*.py' 2>/dev/null)" || status=$?
+    if [[ "${status}" -ge 2 ]]; then
+        echo "ERROR: Failed to scan ${ACTION_DIR} for time.sleep" >&2
+        exit 1
+    fi
+    if [[ -n "${matches}" ]]; then
+        printf '%s\n' "${matches}" | grep -v 'plugins/action/base_action.py:' || true
+    fi
+}
+
+POLL_MATCHES="$(grep_action_plugins "${POLL_PATTERN}")"
+POLL_MATCHES="$(printf '%s\n' "${POLL_MATCHES}" | grep -v 'plugins/action/base_action.py:' || true)"
+
+SLEEP_MATCHES="$(sleep_action_plugins)"
+
+if [[ -n "${POLL_MATCHES}" || -n "${SLEEP_MATCHES}" ]]; then
+    echo "ERROR: Action plugins must not implement job wait/poll logic." >&2
+    echo "Move wait, interval, and timeout handling to PlatformService.execute()" >&2
+    echo "(shared wait_for_completion helper). See docs/09-agent-collaboration.md" >&2
+    echo "section 10 (invariant 7) and docs/07-adding-resources.md section 4c." >&2
+    echo "Example: https://github.com/ansible/ansible.platform/pull/227" >&2
+    if [[ -n "${POLL_MATCHES}" ]]; then
+        printf '%s\n' "${POLL_MATCHES}" >&2
+    fi
+    if [[ -n "${SLEEP_MATCHES}" ]]; then
+        printf '%s\n' "${SLEEP_MATCHES}" >&2
+    fi
     exit 1
 fi
 

--- a/tools/check_action_plugin_invariants.sh
+++ b/tools/check_action_plugin_invariants.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Enforce SDK execution invariants: no HTTP in action plugins.
+# See docs/09-agent-collaboration.md §10 and docs/05-design-principles.md §3a.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ACTION_DIR="${ROOT}/plugins/action"
+
+if ! command -v rg >/dev/null 2>&1; then
+    echo "ERROR: ripgrep (rg) is required to run check_action_plugin_invariants" >&2
+    exit 1
+fi
+
+PATTERN='manager\.session|import requests|from requests import|from requests\.'
+
+if rg -q "${PATTERN}" "${ACTION_DIR}"; then
+    echo "ERROR: Action plugins must not perform HTTP directly." >&2
+    echo "Use PlatformService.execute() and transform mixins instead." >&2
+    echo "See docs/09-agent-collaboration.md section 10." >&2
+    rg -n "${PATTERN}" "${ACTION_DIR}" >&2 || true
+    exit 1
+fi
+
+echo "check_action_plugin_invariants: OK"


### PR DESCRIPTION
## Summary

- Document **SDK execution invariants** so resource logic (associations, surveys, copy, controller sub-endpoints) stays in transform mixins and `PlatformService.execute()`, not in action plugins.
- Fix **Pattern C** guidance in the platform onboarding skill and cheatsheet — Pattern C is thin `run()` orchestration via `manager.execute()`, not custom HTTP.
- Add **`make check_action_plugin_invariants`** (and linting CI job) to fail PRs that introduce `manager.session` or `requests` under `plugins/action/`.
- Reference [#206](https://github.com/ansible/ansible.platform/pull/206) as the concrete consumer that breaks when logic is Ansible-only (follow-up to review feedback on [#228](https://github.com/ansible/ansible.platform/pull/228)).

## Files touched

| Area | Change |
|------|--------|
| `docs/05-design-principles.md` | New §3a — SDK consumer parity |
| `docs/07-adding-resources.md` | New §4a — secondary endpoints / controller resources |
| `docs/09-agent-collaboration.md` | New §10 — agent invariants; expanded anti-pattern §11.1 |
| `CONTRIBUTING.md`, `docs/README.md` | Point AI agents at invariants |
| `.claude/skills/platform-onboarding/` | Correct Pattern C; agent notes |
| `tools/check_action_plugin_invariants.sh` | CI/local guard |
| `.github/workflows/linting.yml` | New matrix job |

## Test plan

- [x] `make check_action_plugin_invariants` passes on `devel`
- [ ] Linting CI (`action-plugin-invariants` job) passes
- [ ] Changelog / docs checks pass


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded guidance for secondary endpoints, associations, copy workflows, and Controller resources.
  - Clarified consistent SDK execution practices, launch and job-wait handling, and where resource-specific logic belongs.
  - Updated onboarding, contribution, collaboration, and design-principle documentation.

- **Quality Improvements**
  - Added automated checks for prohibited direct HTTP access, unauthorized polling, and sleep usage in action plugins.
  - Integrated invariant validation into standard CI checks and added a local command.
  - Documented the new execution safeguards in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->